### PR TITLE
Quick-fix for Edit'Set* cases when old Text value is empty

### DIFF
--- a/lib/View.hs
+++ b/lib/View.hs
@@ -413,7 +413,8 @@ renderEdit globalState edit = do
     Edit'SetCategoryNotes catId oldNotes newNotes -> do
       p_ $ (if (T.null oldNotes) then "added" else "changed") >> " notes of category " >> printCategory catId
       table_ $ tr_ $ do
-        td_ $ blockquote_ $ toHtml (toMarkdownBlock oldNotes)
+        unless (T.null oldNotes) $
+          td_ $ blockquote_ $ toHtml (toMarkdownBlock oldNotes)
         td_ $ blockquote_ $ toHtml (toMarkdownBlock newNotes)
     Edit'SetCategoryProsConsEnabled catId _oldVal newVal -> do
       if newVal == True
@@ -443,24 +444,28 @@ renderEdit globalState edit = do
     Edit'SetItemDescription itemId oldDescr newDescr -> do
       p_ $ (if (T.null oldDescr) then "added" else "changed") >> " description of item " >> printItem itemId
       table_ $ tr_ $ do
-        td_ $ blockquote_ $ toHtml (toMarkdownBlock oldDescr)
+        unless (T.null oldDescr) $
+          td_ $ blockquote_ $ toHtml (toMarkdownBlock oldDescr)
         td_ $ blockquote_ $ toHtml (toMarkdownBlock newDescr)
     Edit'SetItemNotes itemId oldNotes newNotes -> do
       p_ $ (if (T.null oldNotes) then "added" else "changed") >> " notes of item " >> printItem itemId
       table_ $ tr_ $ do
-        td_ $ blockquote_ $ toHtml (toMarkdownBlock oldNotes)
+        unless (T.null oldNotes) $
+          td_ $ blockquote_ $ toHtml (toMarkdownBlock oldNotes)
         td_ $ blockquote_ $ toHtml (toMarkdownBlock newNotes)
     Edit'SetItemEcosystem itemId oldEcosystem newEcosystem -> do
       p_ $ (if (T.null oldEcosystem) then "added" else "changed") >> " ecosystem of item " >> printItem itemId
       table_ $ tr_ $ do
-        td_ $ blockquote_ $ toHtml (toMarkdownBlock oldEcosystem)
+        unless (T.null oldEcosystem) $
+          td_ $ blockquote_ $ toHtml (toMarkdownBlock oldEcosystem)
         td_ $ blockquote_ $ toHtml (toMarkdownBlock newEcosystem)
 
     -- Change trait properties
     Edit'SetTraitContent itemId _traitId oldContent newContent -> do
       p_ $ (if (T.null oldContent) then "added" else "changed") >> " trait of item " >> printItem itemId
       table_ $ tr_ $ do
-        td_ $ blockquote_ $ p_ (toHtml (toMarkdownInline oldContent))
+        unless (T.null oldContent) $
+          td_ $ blockquote_ $ p_ (toHtml (toMarkdownInline oldContent))
         td_ $ blockquote_ $ p_ (toHtml (toMarkdownInline newContent))
 
     -- Delete

--- a/lib/View.hs
+++ b/lib/View.hs
@@ -411,7 +411,7 @@ renderEdit globalState edit = do
       " from " >> quote (toHtml (show oldStatus))
       " to "   >> quote (toHtml (show newStatus))
     Edit'SetCategoryNotes catId oldNotes newNotes -> do
-      p_ $ "changed notes of category " >> printCategory catId
+      p_ $ (if (T.null oldNotes) then "added" else "changed") >> " notes of category " >> printCategory catId
       table_ $ tr_ $ do
         td_ $ blockquote_ $ toHtml (toMarkdownBlock oldNotes)
         td_ $ blockquote_ $ toHtml (toMarkdownBlock newNotes)
@@ -441,24 +441,24 @@ renderEdit globalState edit = do
       " from " >> code_ (toHtml (show oldKind))
       " to "   >> code_ (toHtml (show newKind))
     Edit'SetItemDescription itemId oldDescr newDescr -> do
-      p_ $ "changed description of item " >> printItem itemId
+      p_ $ (if (T.null oldDescr) then "added" else "changed") >> " description of item " >> printItem itemId
       table_ $ tr_ $ do
         td_ $ blockquote_ $ toHtml (toMarkdownBlock oldDescr)
         td_ $ blockquote_ $ toHtml (toMarkdownBlock newDescr)
     Edit'SetItemNotes itemId oldNotes newNotes -> do
-      p_ $ "changed notes of item " >> printItem itemId
+      p_ $ (if (T.null oldNotes) then "added" else "changed") >> " notes of item " >> printItem itemId
       table_ $ tr_ $ do
         td_ $ blockquote_ $ toHtml (toMarkdownBlock oldNotes)
         td_ $ blockquote_ $ toHtml (toMarkdownBlock newNotes)
     Edit'SetItemEcosystem itemId oldEcosystem newEcosystem -> do
-      p_ $ "changed ecosystem of item " >> printItem itemId
+      p_ $ (if (T.null oldEcosystem) then "added" else "changed") >> " ecosystem of item " >> printItem itemId
       table_ $ tr_ $ do
         td_ $ blockquote_ $ toHtml (toMarkdownBlock oldEcosystem)
         td_ $ blockquote_ $ toHtml (toMarkdownBlock newEcosystem)
 
     -- Change trait properties
     Edit'SetTraitContent itemId _traitId oldContent newContent -> do
-      p_ $ "changed trait of item " >> printItem itemId
+      p_ $ (if (T.null oldContent) then "added" else "changed") >> " trait of item " >> printItem itemId
       table_ $ tr_ $ do
         td_ $ blockquote_ $ p_ (toHtml (toMarkdownInline oldContent))
         td_ $ blockquote_ $ p_ (toHtml (toMarkdownInline newContent))


### PR DESCRIPTION
Quick Fix to issue #96.

+ Currently, when old `Text` type value is empty, the descriptive text uses the word _"added"_ instead of _"changed"_. Other than that, the table column for the empty old value still exists.
(See image below for example)
![image](https://cloud.githubusercontent.com/assets/8472087/19419095/ecb2bd98-93ed-11e6-9455-44c0e23afcad.png)
Let me know if empty value columns require removal. That will require some more ninja chops. :hocho: 

+ Only some of the cases matching `Edit'Set*` have been modified. The ones which have not been touched are those which either have default old values which are not empty or `null`; _or_ have a default enumerated value assigned to them (system-defined or `Nothing`), at the time of creation.

==

I am an absolute _noob_ when it comes to Haskell. 
+ I hope my use of the `if-then-else` construct was justified (it seems to get the desired effect).
+ When I needed to check if a `Data.Text` type object was empty, I referred to https://github.com/aelve/guide/blob/master/lib/View.hs#L62-L64 and only `oldValue == T.empty` or 
`(T.null oldValue)` seemed to work. I used the latter. (I don't fully understand why `oldValue == Text.empty` or `(Text.null oldValue)` don't work. I'll leave that as is.)