### PR TITLE
Add no-js option for building

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -1,9 +1,14 @@
 import Distribution.Simple
 import System.Process
+import System.Environment (lookupEnv)
 
 main = do
-  hooks <- buildJS simpleUserHooks
-  defaultMainWithHooks hooks
+  js <- lookupEnv "NO_JS"
+  case js of
+    Just "true" -> defaultMain
+    _           -> do
+      hooks <- buildJS simpleUserHooks
+      defaultMainWithHooks hooks
 
 buildJS hooks = do
   let originalPostBuild = postBuild hooks


### PR DESCRIPTION
Rebuilding JS everytime doesn't seem to be okay when JS files are not changed. I would like to add option to build without it. 
Now it can be done with `NO_JS=true ./b` command.