### PR TITLE
Force use of `UTF-8`

### DIFF
--- a/src/Guide/Main.hs
+++ b/src/Guide/Main.hs
@@ -53,6 +53,7 @@ import Data.Serialize.Get as Cereal
 -- IO
 import System.IO
 import qualified SlaveThread as Slave
+import GHC.IO.Encoding (setLocaleEncoding, utf8)
 -- Catching signals
 import System.Posix.Signals
 -- Watching the templates directory
@@ -136,6 +137,8 @@ lucidWithConfig x = do
 -- | Start the site.
 main :: IO ()
 main = do
+  -- force to use UTF-8
+  setLocaleEncoding utf8
   config <- readConfig
   mainWith config
 

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -4,8 +4,8 @@
 
 module Main (main) where
 
-
 import BasePrelude
+import GHC.IO.Encoding (setLocaleEncoding, utf8)
 -- Testing
 import Test.Hspec
 
@@ -17,6 +17,8 @@ import qualified MergeSpec
 
 main :: IO ()
 main = do
+  -- force to use UTF-8
+  setLocaleEncoding utf8
   hspec $ do
     MarkdownSpec.tests
     MergeSpec.tests


### PR DESCRIPTION
to avoid issue of ` hGetContents: invalid argument (invalid byte sequence)`, which seems to be on Ubuntu only (see discussion at Slack https://aelve.slack.com/archives/C3UQX6F45/p1507399615000050).

_Note:_ `Hakyll` recommands to do the same thing in its `faq` "HGETCONTENTS: INVALID ARGUMENT” OR “COMMITBUFFER: INVALID ARGUMENT" https://jaspervdj.be/hakyll/tutorials/faq.html#hgetcontents-invalid-argument-or-commitbuffer-invalid-argument  _I know we are not using Hakyll :)_