### PR TITLE
Use custom nix file

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,8 @@
+with import <nixpkgs> { };
+
+haskell.lib.buildStackProject {
+  name = "guide";
+  inherit ghc;
+  buildInputs = [ git ncurses zlib ];
+  LANG = "en_US.UTF-8";
+}

--- a/src/Guide/Main.hs
+++ b/src/Guide/Main.hs
@@ -53,7 +53,6 @@ import Data.Serialize.Get as Cereal
 -- IO
 import System.IO
 import qualified SlaveThread as Slave
-import GHC.IO.Encoding (setLocaleEncoding, utf8)
 -- Catching signals
 import System.Posix.Signals
 -- Watching the templates directory
@@ -137,8 +136,6 @@ lucidWithConfig x = do
 -- | Start the site.
 main :: IO ()
 main = do
-  -- force to use UTF-8
-  setLocaleEncoding utf8
   config <- readConfig
   mainWith config
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,6 +11,9 @@ packages:
     commit: 26e5f8c7f62ebce66ef19e5bd573af21c16fe2b1
   extra-dep: true
 
+nix:
+  shell-file: shell.nix
+
 extra-deps:
 - text-all-0.4.1.0
 - cmark-sections-0.3.0

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -5,7 +5,6 @@
 module Main (main) where
 
 import BasePrelude
-import GHC.IO.Encoding (setLocaleEncoding, utf8)
 -- Testing
 import Test.Hspec
 
@@ -17,8 +16,6 @@ import qualified MergeSpec
 
 main :: IO ()
 main = do
-  -- force to use UTF-8
-  setLocaleEncoding utf8
   hspec $ do
     MarkdownSpec.tests
     MergeSpec.tests


### PR DESCRIPTION
and revert forcing of `UTF-8` in code. Because issues described in #211 is not based on `Ubuntu` (as @vrom911 confirmed), but more a `Nix` related thing. By using `Nix` (as I do) the `LANG` issue can be fixed by adding a custom `shell.nix`.

For more information check:
* "Enabling nix causes LANG to be lost" https://github.com/commercialhaskell/stack/issues/2358
* "Using a custom shell.nix file" with `stack` https://docs.haskellstack.org/en/stable/nix_integration/#using-a-custom-shellnix-file