### PR TITLE
Add categories to the right groups

### DIFF
--- a/front/client/components/AddCategoryDialog.vue
+++ b/front/client/components/AddCategoryDialog.vue
@@ -93,7 +93,10 @@ export default class AddCategoryDialog extends Vue {
     }
     // TODO move to vuex
     // TODO handle errors
-    const createdId = await CategoryService.createCategory({ title: this.categoryName })
+    const createdId = await CategoryService.createCategory({
+      title: this.categoryName,
+      group: this.groupName
+    })
     this.$store.dispatch('category/loadCategoryList')
     window.open(`http://aelve.com:4801/haskell/${createdId}`, '_blank')
     this.isDialogOpen = false

--- a/front/client/components/AddCategoryDialog.vue
+++ b/front/client/components/AddCategoryDialog.vue
@@ -95,7 +95,7 @@ export default class AddCategoryDialog extends Vue {
     // TODO handle errors
     const createdId = await CategoryService.createCategory({
       title: this.categoryName,
-      group: this.groupName
+      group: this.groupNameInternal
     })
     this.$store.dispatch('category/loadCategoryList')
     window.open(`http://aelve.com:4801/haskell/${createdId}`, '_blank')

--- a/front/client/service/Category.ts
+++ b/front/client/service/Category.ts
@@ -6,10 +6,11 @@ class CategoryService {
     return data
   }
 
-  async  createCategory({ title }: ICategory): Promise<ICategory[]> {
+  async  createCategory({ title, group }: ICategory): Promise<ICategory[]> {
     const { data } = await axios.post('api/category', null, {
       params: {
-        title
+        title,
+        group
       }
     })
     return data

--- a/src/Guide/Api/Types.hs
+++ b/src/Guide/Api/Types.hs
@@ -90,11 +90,16 @@ data CategorySite route = CategorySite
   , _createCategory :: route :-
       Summary "Create a new category"
       :> Description "Returns the ID of the created category.\n\n\
-                     \If a category with the same title already exists, \
-                     \returns its ID instead."
+                     \If a category with the same title already exists \
+                     \in the group, returns its ID instead."
       :> ErrorResponse 400 "'title' not provided"
       :> "category"
-      :> QueryParam' '[Required, Strict] "title" Text
+      :> QueryParam' '[Required, Strict,
+                       Description "Title of the newly created category"]
+           "title" Text
+      :> QueryParam' '[Required, Strict,
+                       Description "Group to put the category into"]
+           "group" Text
       :> Post '[JSON] (Uid Category)
 
   , _deleteCategory :: route :-

--- a/src/Guide/Handlers.hs
+++ b/src/Guide/Handlers.hs
@@ -274,7 +274,7 @@ addMethods = do
       Nothing -> do
         catId <- randomShortUid
         time <- liftIO getCurrentTime
-        (edit, newCategory) <- dbUpdate (AddCategory catId title' time)
+        (edit, newCategory) <- dbUpdate (AddCategory catId title' "Miscellaneous" time)
         invalidateCache' (CacheCategory catId)
         addEdit edit
         return newCategory

--- a/src/Guide/ServerStuff.hs
+++ b/src/Guide/ServerStuff.hs
@@ -153,7 +153,7 @@ addEdit ed = do
 -- been deleted; this should change.
 undoEdit :: (MonadIO m, HasSpock m, SpockState m ~ ServerState)
          => Edit -> m (Either String ())
-undoEdit (Edit'AddCategory catId _) = do
+undoEdit (Edit'AddCategory catId _ _) = do
   void <$> dbUpdate (DeleteCategory catId)
 undoEdit (Edit'AddItem _catId itemId _) = do
   void <$> dbUpdate (DeleteItem itemId)
@@ -245,7 +245,7 @@ invalidateCacheForEdit
 invalidateCacheForEdit ed = do
   gs <- dbQuery GetGlobalState
   mapM_ (invalidateCache gs) $ case ed of
-    Edit'AddCategory catId _ ->
+    Edit'AddCategory catId _ _ ->
         [CacheCategory catId]
     -- Normally invalidateCache should invalidate item's category
     -- automatically, but in this case it's *maybe* possible that the item

--- a/src/Guide/State.hs
+++ b/src/Guide/State.hs
@@ -345,13 +345,14 @@ getTrait itemId traitId = view (itemById itemId . traitById traitId)
 addCategory
   :: Uid Category    -- ^ New category's id
   -> Text            -- ^ Title
+  -> Text            -- ^ Group
   -> UTCTime         -- ^ Creation time
   -> Acid.Update GlobalState (Edit, Category)
-addCategory catId title' created' = do
+addCategory catId title' group' created' = do
   let newCategory = Category {
         _categoryUid = catId,
         _categoryTitle = title',
-        _categoryGroup_ = "Miscellaneous",
+        _categoryGroup_ = group',
         _categoryEnabledSections = S.fromList [
             ItemProsConsSection,
             ItemEcosystemSection,
@@ -363,7 +364,7 @@ addCategory catId title' created' = do
         _categoryItems = [],
         _categoryItemsDeleted = [] }
   categories %= (newCategory :)
-  let edit = Edit'AddCategory catId title'
+  let edit = Edit'AddCategory catId title' group'
   return (edit, newCategory)
 
 addItem

--- a/src/Guide/Types/Edit.hs
+++ b/src/Guide/Types/Edit.hs
@@ -19,8 +19,6 @@ where
 
 import Imports
 
--- Containers
-import qualified Data.Set as S
 -- Network
 import Data.IP
 -- acid-state
@@ -36,7 +34,8 @@ data Edit
   -- Add
   = Edit'AddCategory {
       editCategoryUid   :: Uid Category,
-      editCategoryTitle :: Text }
+      editCategoryTitle :: Text,
+      editCategoryGroup :: Text }
   | Edit'AddItem {
       editCategoryUid   :: Uid Category,
       editItemUid       :: Uid Item,
@@ -133,11 +132,13 @@ data Edit
 
   deriving (Eq, Show)
 
-deriveSafeCopySimple 7 'extension ''Edit
+deriveSafeCopySimple 8 'extension ''Edit
 
-genVer ''Edit 6 [
+genVer ''Edit 7 [
   -- Add
-  Copy 'Edit'AddCategory,
+  Custom "Edit'AddCategory" [
+      ("editCategoryUid"  , [t|Uid Category|]),
+      ("editCategoryTitle", [t|Text|]) ],
   Copy 'Edit'AddItem,
   Copy 'Edit'AddPro,
   Copy 'Edit'AddCon,
@@ -146,18 +147,7 @@ genVer ''Edit 6 [
   Copy 'Edit'SetCategoryGroup,
   Copy 'Edit'SetCategoryNotes,
   Copy 'Edit'SetCategoryStatus,
-  Custom "Edit'SetCategoryProsConsEnabled" [
-      ("editCategoryUid"                , [t|Uid Category|]),
-      ("_editCategoryProsConsEnabled"   , [t|Bool|]),
-      ("editCategoryNewProsConsEnabled" , [t|Bool|]) ],
-  Custom "Edit'SetCategoryEcosystemEnabled" [
-      ("editCategoryUid"                , [t|Uid Category|]),
-      ("_editCategoryEcosystemEnabled"  , [t|Bool|]),
-      ("editCategoryNewEcosystemEnabled", [t|Bool|]) ],
-  Custom "Edit'SetCategoryNotesEnabled" [
-      ("editCategoryUid"                , [t|Uid Category|]),
-      ("_editCategoryNotesEnabled"      , [t|Bool|]),
-      ("editCategoryNewNotesEnabled"    , [t|Bool|]) ],
+  Copy 'Edit'ChangeCategoryEnabledSections,
   -- Change item properties
   Copy 'Edit'SetItemName,
   Copy 'Edit'SetItemLink,
@@ -176,12 +166,17 @@ genVer ''Edit 6 [
   Copy 'Edit'MoveItem,
   Copy 'Edit'MoveTrait ]
 
-deriveSafeCopySimple 6 'base ''Edit_v6
+deriveSafeCopySimple 7 'base ''Edit_v7
 
 instance Migrate Edit where
-  type MigrateFrom Edit = Edit_v6
-  migrate = $(migrateVer ''Edit 6 [
-    CopyM 'Edit'AddCategory,
+  type MigrateFrom Edit = Edit_v7
+  migrate = $(migrateVer ''Edit 7 [
+    CustomM "Edit'AddCategory" [|\x ->
+        Edit'AddCategory
+          { editCategoryUid = editCategoryUid_v7 x
+          , editCategoryTitle = editCategoryTitle_v7 x
+          , editCategoryGroup = toText "Miscellaneous"
+          } |],
     CopyM 'Edit'AddItem,
     CopyM 'Edit'AddPro,
     CopyM 'Edit'AddCon,
@@ -190,24 +185,7 @@ instance Migrate Edit where
     CopyM 'Edit'SetCategoryGroup,
     CopyM 'Edit'SetCategoryNotes,
     CopyM 'Edit'SetCategoryStatus,
-    CustomM "Edit'SetCategoryProsConsEnabled" [|\x ->
-        if editCategoryNewProsConsEnabled_v6 x
-          then Edit'ChangeCategoryEnabledSections (editCategoryUid_v6 x)
-                 (S.singleton ItemProsConsSection) mempty
-          else Edit'ChangeCategoryEnabledSections (editCategoryUid_v6 x)
-                 mempty (S.singleton ItemProsConsSection) |],
-    CustomM "Edit'SetCategoryEcosystemEnabled" [|\x ->
-        if editCategoryNewEcosystemEnabled_v6 x
-          then Edit'ChangeCategoryEnabledSections (editCategoryUid_v6 x)
-                 (S.singleton ItemEcosystemSection) mempty
-          else Edit'ChangeCategoryEnabledSections (editCategoryUid_v6 x)
-                 mempty (S.singleton ItemEcosystemSection) |],
-    CustomM "Edit'SetCategoryNotesEnabled" [|\x ->
-        if editCategoryNewNotesEnabled_v6 x
-          then Edit'ChangeCategoryEnabledSections (editCategoryUid_v6 x)
-                 (S.singleton ItemNotesSection) mempty
-          else Edit'ChangeCategoryEnabledSections (editCategoryUid_v6 x)
-                 mempty (S.singleton ItemNotesSection) |],
+    CopyM 'Edit'ChangeCategoryEnabledSections,
     -- Change item properties
     CopyM 'Edit'SetItemName,
     CopyM 'Edit'SetItemLink,

--- a/src/Guide/Views.hs
+++ b/src/Guide/Views.hs
@@ -412,8 +412,9 @@ renderEdit globalState edit = do
 
   case edit of
     -- Add
-    Edit'AddCategory _catId title' -> p_ $ do
+    Edit'AddCategory _catId title' group' -> p_ $ do
       "added category " >> quote (toHtml title')
+      " to group " >> quote (toHtml group')
     Edit'AddItem catId _itemId name' -> p_ $ do
       "added item " >> printItem _itemId
       " (initially called " >> quote (toHtml name') >> ")"


### PR DESCRIPTION
Previously we always added categories to the "Miscellaneous" group, regardless of what was in the "Add category" dialog. This PR fixes this.