### PR TITLE
Expose ToC for notes in Items

### DIFF
--- a/src/Guide/Api/Types.hs
+++ b/src/Guide/Api/Types.hs
@@ -253,7 +253,7 @@ data CItemFull = CItemFull
   , cifNotes       :: CMarkdown                ? "Notes (Markdown)"
   , cifLink        :: Maybe Url                ? "Link to the official site, if exists"
   , cifKind        :: ItemKind                 ? "Item kind, e.g. library, ..."
-  , cifToc         :: Forest (CMarkdown, Text) ? "Table of Contents"
+  , cifToc         :: Forest CHeading          ? "Table of contents"
   } deriving (Show, Generic)
 
 instance A.ToJSON CItemFull where
@@ -290,9 +290,7 @@ toCItemFull Item{..} = CItemFull
   , cifToc         = H $ map treeToCMD (markdownTreeMdTOC _itemNotes)
   }
   where
-    treeToCMD = fmap
-        (\(Heading mdIn slug) -> (toCMarkdown mdIn, slug)
-        )
+    treeToCMD = fmap toCHeading
 
 -- | Client type of 'Trait'
 data CTrait = CTrait
@@ -342,6 +340,20 @@ instance ToCMarkdown MarkdownTree where
     { text = H $ md^.mdSource
     , html = H $ toText . renderText $ toHtml md
     }
+
+data CHeading = CHeading
+  { chContent :: CMarkdown    ? "Rendered heading"
+  , chSlug    :: Text         ? "In-page anchor for linking"
+  } deriving (Show, Generic)
+
+instance A.ToJSON CHeading
+instance ToSchema CHeading
+
+toCHeading :: Heading -> CHeading
+toCHeading h = CHeading
+  { chContent = H $ toCMarkdown $ headingMd h
+  , chSlug    = H $ headingSlug h
+  }
 
 ----------------------------------------------------------------------------
 -- Search client types

--- a/src/Guide/Api/Types.hs
+++ b/src/Guide/Api/Types.hs
@@ -43,8 +43,8 @@ import Servant.API.Generic
 
 import Guide.Api.Error
 import Guide.Api.Utils
-import Guide.Markdown (MarkdownBlock, MarkdownInline, MarkdownTree, markdownTreeMdTOC, mdHtml,
-                       mdSource, renderMD)
+import Guide.Markdown (Heading (..), MarkdownBlock, MarkdownInline, MarkdownTree, markdownTreeMdTOC,
+                       mdHtml, mdSource)
 import Guide.Search
 import Guide.Types.Core as G
 import Guide.Utils (Uid (..), Url)
@@ -242,18 +242,18 @@ instance ToSchema CItemInfo where
 
 -- | Client type of 'Item'
 data CItemFull = CItemFull
-  { cifUid         :: Uid Item         ? "Item ID"
-  , cifName        :: Text             ? "Item name"
-  , cifCreated     :: UTCTime          ? "When the item was created"
-  , cifGroup       :: Maybe Text       ? "Item group"
-  , cifDescription :: CMarkdown        ? "Item summary (Markdown)"
-  , cifPros        :: [CTrait]         ? "Pros (positive traits)"
-  , cifCons        :: [CTrait]         ? "Cons (negative traits)"
-  , cifEcosystem   :: CMarkdown        ? "The ecosystem description (Markdown)"
-  , cifNotes       :: CMarkdown        ? "Notes (Markdown)"
-  , cifLink        :: Maybe Url        ? "Link to the official site, if exists"
-  , cifKind        :: ItemKind         ? "Item kind, e.g. library, ..."
-  , cifToc         :: Forest CMarkdown ? "Table of Contents"
+  { cifUid         :: Uid Item                 ? "Item ID"
+  , cifName        :: Text                     ? "Item name"
+  , cifCreated     :: UTCTime                  ? "When the item was created"
+  , cifGroup       :: Maybe Text               ? "Item group"
+  , cifDescription :: CMarkdown                ? "Item summary (Markdown)"
+  , cifPros        :: [CTrait]                 ? "Pros (positive traits)"
+  , cifCons        :: [CTrait]                 ? "Cons (negative traits)"
+  , cifEcosystem   :: CMarkdown                ? "The ecosystem description (Markdown)"
+  , cifNotes       :: CMarkdown                ? "Notes (Markdown)"
+  , cifLink        :: Maybe Url                ? "Link to the official site, if exists"
+  , cifKind        :: ItemKind                 ? "Item kind, e.g. library, ..."
+  , cifToc         :: Forest (CMarkdown, Text) ? "Table of Contents"
   } deriving (Show, Generic)
 
 instance A.ToJSON CItemFull where
@@ -291,9 +291,7 @@ toCItemFull Item{..} = CItemFull
   }
   where
     treeToCMD = fmap
-        (\(nodes, source) -> CMarkdown
-            (H source)
-            (H $ toText $ renderMD nodes)
+        (\(Heading mdIn slug) -> (toCMarkdown mdIn, slug)
         )
 
 -- | Client type of 'Trait'

--- a/src/Guide/Markdown.hs
+++ b/src/Guide/Markdown.hs
@@ -276,19 +276,19 @@ toMarkdownTree idPrefix s = MarkdownTree {
     tree = renderContents . slugifyDocument slugify $
              nodesToDocument (WithSource s blocks)
     --
-    toc :: Forest Heading  -- (heading, slug)
+    toc :: Forest Heading
     toc = sections tree
             & each.each
-            %~ (\Section{..} -> Heading (nodesToMdInline $ stripSource heading) headingAnn)
+            %~ (\Section{..} -> Heading (nodesToMdInline heading) headingAnn)
 
-    nodesToMdInline :: [MD.Node] -> MarkdownInline
-    nodesToMdInline n = MarkdownInline
-        { markdownInlineMdSource   = stringify n
+    nodesToMdInline :: WithSource [MD.Node] -> MarkdownInline
+    nodesToMdInline (WithSource src nodes) = MarkdownInline
+        { markdownInlineMdSource   = src
         , markdownInlineMdHtml     = html
         , markdownInlineMdMarkdown = inlines
         }
       where
-        inlines = extractInlines n
+        inlines = extractInlines nodes
         html = renderMD inlines
 
 renderContents :: Document a b -> Document a ByteString

--- a/src/Guide/Markdown.hs
+++ b/src/Guide/Markdown.hs
@@ -16,7 +16,7 @@ module Guide.Markdown
   MarkdownInline(..),
   MarkdownBlock(..),
   MarkdownTree(..),
-  Heading (..),
+  Heading(..),
 
   -- * Lenses
   mdHtml,
@@ -87,6 +87,7 @@ data MarkdownTree = MarkdownTree {
   markdownTreeMdTOC      :: Forest Heading }
   deriving (Generic, Data)
 
+-- | Table-of-contents heading
 data Heading = Heading
     { headingMd   :: MarkdownInline
     , headingSlug :: Text

--- a/src/Guide/Markdown.hs
+++ b/src/Guide/Markdown.hs
@@ -318,8 +318,7 @@ instance Show MarkdownBlock where
   show = show . view mdSource
 instance Show MarkdownTree where
   show = show . view mdSource
-instance Show Heading where
-  show (Heading hIn txt) = "Heading " ++ show hIn ++ " " ++ show txt
+deriving instance Show Heading
 
 instance A.ToJSON MarkdownInline where
   toJSON md = A.object [

--- a/src/Guide/Views/Item.hs
+++ b/src/Guide/Views/Item.hs
@@ -41,7 +41,6 @@ import Guide.Types.Core
 import Guide.Utils
 import Guide.Views.Utils
 
-import qualified CMark as MD
 import qualified Data.Aeson as A
 import qualified Data.Map as M
 import qualified Data.Text.IO as T
@@ -262,10 +261,10 @@ renderItemNotes category item = cached (CacheItemNotes (item^.uid)) $ do
     a_ [href_ notesLink] $
       strong_ "Notes"
 
-    let renderTree :: Monad m => Forest ([MD.Node], Text) -> HtmlT m ()
+    let renderTree :: Monad m => Forest Heading -> HtmlT m ()
         renderTree [] = return ()
         renderTree xs = ul_ $ do
-          for_ xs $ \(Node (is, id') children) -> li_ $ do
+          for_ xs $ \(Node {-(is, id')-} (Heading hMd id') children) -> li_ $ do
             let handler = fromJS (JS.expandItemNotes [item^.uid])
                 -- The link has to be absolute because sometimes we are
                 -- looking at items from pages different from the proper
@@ -278,7 +277,7 @@ renderItemNotes category item = cached (CacheItemNotes (item^.uid)) $ do
                 -- start happening and then it's better to be prepared.
                 fullLink = categoryLink category <> "#" <> id'
             a_ [href_ fullLink, onclick_ handler] $
-              toHtmlRaw (renderMD is)
+              toHtmlRaw (markdownInlineMdHtml hMd)
             renderTree children
     let renderTOC = do
           let toc = item^.notes.mdTOC

--- a/tests/MarkdownSpec.hs
+++ b/tests/MarkdownSpec.hs
@@ -134,11 +134,10 @@ tests = describe "Markdown" $ do
                          subForest = [] }]}]}
     it "has a correct TOC" $ do
       let s = "x\n\n# foo\n\n## foo\n\ny"
-      let headingInline = toMarkdownInline "foo"
       (toMarkdownTree "i-" s ^. mdTOC) `shouldBe` [
-        Node {rootLabel = Heading headingInline "i-foo",
+        Node {rootLabel = Heading (toMarkdownInline "# foo\n\n") "i-foo",
               subForest = [
-                 Node {rootLabel = Heading headingInline "i-foo_",
+                 Node {rootLabel = Heading (toMarkdownInline "## foo\n\n") "i-foo_",
                        subForest = [] }]}]
 
 getTags :: Text -> [Text]

--- a/tests/MarkdownSpec.hs
+++ b/tests/MarkdownSpec.hs
@@ -9,15 +9,15 @@ import BasePrelude
 -- Lenses
 import Lens.Micro.Platform
 -- Text
+import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
-import Data.Text (Text)
 -- HTML
+import Lucid (ToHtml, renderText, toHtml)
 import Text.HTML.TagSoup hiding (sections)
-import Lucid (ToHtml, toHtml, renderText)
 -- Markdown
 import CMark hiding (Node)
-import qualified CMark as MD (Node(..))
+import qualified CMark as MD (Node (..))
 import CMark.Sections
 import Data.Tree
 -- Testing
@@ -134,11 +134,11 @@ tests = describe "Markdown" $ do
                          subForest = [] }]}]}
     it "has a correct TOC" $ do
       let s = "x\n\n# foo\n\n## foo\n\ny"
-      let headingMD = MD.Node Nothing (TEXT "foo") []
+      let headingInline = toMarkdownInline "foo"
       (toMarkdownTree "i-" s ^. mdTOC) `shouldBe` [
-        Node {rootLabel = ([headingMD],"i-foo"),
+        Node {rootLabel = Heading headingInline "i-foo",
               subForest = [
-                 Node {rootLabel = ([headingMD],"i-foo_"),
+                 Node {rootLabel = Heading headingInline "i-foo_",
                        subForest = [] }]}]
 
 getTags :: Text -> [Text]


### PR DESCRIPTION

I've checked it manually, at least I can see the entry like this in the response:
```
... "toc":
  [ [ { "text": "item-notes-ajh4pkjz-types-and-modules"
      , "html":"Types and modules"
      }
    , []
    ]
  , [ { "text": "item-notes-ajh4pkjz-unsafe-operations"
      , "html": "Unsafe operations"
      }
    , []
    ]
  ],
```