### PR TITLE
Apply stylish-haskell and format imports section

### DIFF
--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -1,0 +1,59 @@
+steps:
+  - simple_align:
+      cases: true
+      top_level_patterns: true
+      records: true
+
+  # Import cleanup
+  - imports:
+      align: none
+      list_align: after_alias
+      pad_module_names: false
+      long_list_align: inline
+      empty_list_align: inherit
+      list_padding: 4
+      separate_lists: true
+      space_surround: false
+
+  - language_pragmas:
+      style: vertical
+      remove_redundant: true
+
+  # Remove trailing whitespace
+  - trailing_whitespace: {}
+
+columns: 100
+
+newline: native
+
+language_extensions:
+  - BangPatterns
+  - ConstraintKinds
+  - DataKinds
+  - DefaultSignatures
+  - DeriveAnyClass
+  - DeriveDataTypeable
+  - DeriveGeneric
+  - DerivingStrategies	
+  - FlexibleContexts
+  - FlexibleInstances
+  - FunctionalDependencies
+  - GADTs
+  - GeneralizedNewtypeDeriving
+  - InstanceSigs
+  - KindSignatures
+  - LambdaCase
+  - MultiParamTypeClasses
+  - MultiWayIf
+  - NamedFieldPuns
+  - NoImplicitPrelude
+  - OverloadedStrings
+  - QuasiQuotes
+  - RecordWildCards
+  - ScopedTypeVariables
+  - StandaloneDeriving
+  - TemplateHaskell
+  - TupleSections
+  - TypeApplications
+  - TypeFamilies
+  - ViewPatterns

--- a/src/Guide/Api/Error.hs
+++ b/src/Guide/Api/Error.hs
@@ -1,9 +1,9 @@
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE FlexibleInstances   #-}
+{-# LANGUAGE KindSignatures      #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE TypeOperators       #-}
 
 
 module Guide.Api.Error
@@ -13,10 +13,10 @@ module Guide.Api.Error
 
 import Imports
 
+import Data.Swagger
 import GHC.TypeLits
 import Servant
 import Servant.Swagger
-import Data.Swagger
 
 
 -- Taken from https://github.com/haskell-servant/servant-swagger/issues/59

--- a/src/Guide/Api/Methods.hs
+++ b/src/Guide/Api/Methods.hs
@@ -1,22 +1,23 @@
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeFamilies      #-}
+{-# LANGUAGE TypeOperators     #-}
 
 module Guide.Api.Methods where
 
 
 import Imports
 
-import Servant
 import Data.Acid as Acid
-import qualified Data.Text as T
 import Data.Text (Text)
+import Servant
 
-import Guide.Types
-import Guide.State
-import Guide.Utils
 import Guide.Api.Types
+import Guide.State
+import Guide.Types
+import Guide.Utils
+
+import qualified Data.Text as T
 import qualified Guide.Search as Search
 
 ----------------------------------------------------------------------------

--- a/src/Guide/Api/Server.hs
+++ b/src/Guide/Api/Server.hs
@@ -1,7 +1,7 @@
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications  #-}
+{-# LANGUAGE TypeOperators     #-}
 
 
 module Guide.Api.Server
@@ -12,24 +12,25 @@ module Guide.Api.Server
 
 import Imports
 
-import Data.Acid as Acid
+import Data.Swagger.Lens
+import Network.Wai (Middleware)
+import Network.Wai.Handler.Warp (run)
+import Network.Wai.Middleware.Cors (CorsResourcePolicy (..), cors, corsOrigins,
+                                    simpleCorsResourcePolicy)
 import Servant
 import Servant.API.Generic
 import Servant.Server.Generic
 import Servant.Swagger
 import Servant.Swagger.UI
-import Data.Swagger.Lens
-import Network.Wai.Handler.Warp (run)
-import Network.Wai (Middleware)
-import Network.Wai.Middleware.Cors (CorsResourcePolicy (..), cors
-  , corsOrigins, simpleCorsResourcePolicy)
 
 -- putStrLn that works well with concurrency
 import Say (say)
 
-import Guide.State
-import Guide.Api.Types
 import Guide.Api.Methods
+import Guide.Api.Types
+import Guide.State
+
+import Data.Acid as Acid
 
 apiServer :: DB -> Site AsServer
 apiServer db = Site

--- a/src/Guide/Api/Types.hs
+++ b/src/Guide/Api/Types.hs
@@ -1,10 +1,10 @@
+{-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE DeriveGeneric         #-}
-{-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE TypeOperators         #-}
 {-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE TypeOperators         #-}
 
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
@@ -36,18 +36,19 @@ module Guide.Api.Types
 
 import Imports
 
-import qualified Data.Aeson as A
-import Lucid (toHtml, renderText)
+import Lucid (renderText, toHtml)
 import Servant
 import Servant.API.Generic
-import Data.Swagger as S
 
 import Guide.Api.Error
 import Guide.Api.Utils
-import Guide.Types.Core as G
-import Guide.Search
-import Guide.Utils (Uid(..), Url)
 import Guide.Markdown (MarkdownBlock, MarkdownInline, MarkdownTree, mdHtml, mdSource)
+import Guide.Search
+import Guide.Types.Core as G
+import Guide.Utils (Uid (..), Url)
+
+import qualified Data.Aeson as A
+import Data.Swagger as S
 
 ----------------------------------------------------------------------------
 -- Routes
@@ -168,11 +169,11 @@ type Api = ToServant Site AsApi
 -- | A "light-weight" client type of 'Category', which describes a category
 -- but doesn't give the notes or the items.
 data CCategoryInfo = CCategoryInfo
-  { cciUid     :: Uid Category          ? "Category ID"
-  , cciTitle   :: Text                  ? "Category title"
-  , cciCreated :: UTCTime               ? "When the category was created"
-  , cciGroup_  :: Text                  ? "Category group ('grandcategory')"
-  , cciStatus  :: CategoryStatus        ? "Status (done, in progress, ...)"
+  { cciUid     :: Uid Category   ? "Category ID"
+  , cciTitle   :: Text           ? "Category title"
+  , cciCreated :: UTCTime        ? "When the category was created"
+  , cciGroup_  :: Text           ? "Category group ('grandcategory')"
+  , cciStatus  :: CategoryStatus ? "Status (done, in progress, ...)"
   }
   deriving (Show, Generic)
 
@@ -195,12 +196,12 @@ toCCategoryInfo Category{..} = CCategoryInfo
 -- | A "light-weight" client type of 'Category', which gives all available
 -- information about a category
 data CCategoryFull = CCategoryFull
-  { ccfUid :: Uid Category              ? "Category ID"
-  , ccfTitle :: Text                    ? "Category title"
-  , ccfGroup :: Text                    ? "Category group ('grandcategory')"
-  , ccfStatus :: CategoryStatus         ? "Status, e.g. done, in progress, ..."
-  , ccfDescription :: CMarkdown         ? "Category description/notes (Markdown)"
-  , ccfItems :: [CItemFull]             ? "All items in the category"
+  { ccfUid         :: Uid Category   ? "Category ID"
+  , ccfTitle       :: Text           ? "Category title"
+  , ccfGroup       :: Text           ? "Category group ('grandcategory')"
+  , ccfStatus      :: CategoryStatus ? "Status, e.g. done, in progress, ..."
+  , ccfDescription :: CMarkdown      ? "Category description/notes (Markdown)"
+  , ccfItems       :: [CItemFull]    ? "All items in the category"
   }
   deriving (Show, Generic)
 
@@ -223,12 +224,12 @@ toCCategoryFull Category{..} = CCategoryFull
 
 -- | A lightweight info type about an 'Item'
 data CItemInfo = CItemInfo
-  { ciiUid :: Uid Item                   ? "Item ID"
-  , ciiName :: Text                      ? "Item name"
-  , ciiCreated :: UTCTime                ? "When the item was created"
-  , ciiGroup :: Maybe Text               ? "Item group"
-  , ciiLink :: Maybe Url                 ? "Link to the official site, if exists"
-  , ciiKind :: ItemKind                  ? "Item kind, e.g. library, ..."
+  { ciiUid     :: Uid Item   ? "Item ID"
+  , ciiName    :: Text       ? "Item name"
+  , ciiCreated :: UTCTime    ? "When the item was created"
+  , ciiGroup   :: Maybe Text ? "Item group"
+  , ciiLink    :: Maybe Url  ? "Link to the official site, if exists"
+  , ciiKind    :: ItemKind   ? "Item kind, e.g. library, ..."
   } deriving (Show, Generic)
 
 instance A.ToJSON CItemInfo where
@@ -239,17 +240,17 @@ instance ToSchema CItemInfo where
 
 -- | Client type of 'Item'
 data CItemFull = CItemFull
-  { cifUid :: Uid Item                   ? "Item ID"
-  , cifName :: Text                      ? "Item name"
-  , cifCreated :: UTCTime                ? "When the item was created"
-  , cifGroup :: Maybe Text               ? "Item group"
-  , cifDescription :: CMarkdown          ? "Item summary (Markdown)"
-  , cifPros :: [CTrait]                  ? "Pros (positive traits)"
-  , cifCons :: [CTrait]                  ? "Cons (negative traits)"
-  , cifEcosystem :: CMarkdown            ? "The ecosystem description (Markdown)"
-  , cifNotes :: CMarkdown                ? "Notes (Markdown)"
-  , cifLink :: Maybe Url                 ? "Link to the official site, if exists"
-  , cifKind :: ItemKind                  ? "Item kind, e.g. library, ..."
+  { cifUid         :: Uid Item   ? "Item ID"
+  , cifName        :: Text       ? "Item name"
+  , cifCreated     :: UTCTime    ? "When the item was created"
+  , cifGroup       :: Maybe Text ? "Item group"
+  , cifDescription :: CMarkdown  ? "Item summary (Markdown)"
+  , cifPros        :: [CTrait]   ? "Pros (positive traits)"
+  , cifCons        :: [CTrait]   ? "Cons (negative traits)"
+  , cifEcosystem   :: CMarkdown  ? "The ecosystem description (Markdown)"
+  , cifNotes       :: CMarkdown  ? "Notes (Markdown)"
+  , cifLink        :: Maybe Url  ? "Link to the official site, if exists"
+  , cifKind        :: ItemKind   ? "Item kind, e.g. library, ..."
   } deriving (Show, Generic)
 
 instance A.ToJSON CItemFull where
@@ -287,8 +288,8 @@ toCItemFull Item{..} = CItemFull
 
 -- | Client type of 'Trait'
 data CTrait = CTrait
-  { ctUid :: Uid Trait                  ? "Trait ID"
-  , ctContent :: CMarkdown              ? "Trait text (Markdown)"
+  { ctUid     :: Uid Trait ? "Trait ID"
+  , ctContent :: CMarkdown ? "Trait text (Markdown)"
   } deriving (Show, Generic)
 
 instance A.ToJSON CTrait where
@@ -306,8 +307,8 @@ toCTrait trait = CTrait
 
 -- | Client type of 'Markdown'
 data CMarkdown = CMarkdown
-  { text :: Text                        ? "Markdown source"
-  , html :: Text                        ? "Rendered HTML"
+  { text :: Text ? "Markdown source"
+  , html :: Text ? "Rendered HTML"
   } deriving (Show, Generic)
 
 instance A.ToJSON CMarkdown
@@ -371,8 +372,8 @@ instance ToSchema CSearchResult where
 
 -- | A category was found.
 data CSRCategory = CSRCategory
-  { csrcInfo         :: CCategoryInfo  ? "Info about the category"
-  , csrcDescription  :: CMarkdown      ? "Category description"
+  { csrcInfo        :: CCategoryInfo ? "Info about the category"
+  , csrcDescription :: CMarkdown     ? "Category description"
   } deriving (Show, Generic)
 
 instance A.ToJSON CSRCategory where
@@ -383,10 +384,10 @@ instance ToSchema CSRCategory where
 
 -- | An item was found.
 data CSRItem = CSRItem
-  { csriCategory    :: CCategoryInfo    ? "Category that the item belongs to"
-  , csriInfo        :: CItemInfo        ? "Info about the item"
-  , csriDescription :: Maybe CMarkdown  ? "Item description (if the match was found there)"
-  , csriEcosystem   :: Maybe CMarkdown  ? "Item ecosystem (if the match was found there)"
+  { csriCategory    :: CCategoryInfo   ? "Category that the item belongs to"
+  , csriInfo        :: CItemInfo       ? "Info about the item"
+  , csriDescription :: Maybe CMarkdown ? "Item description (if the match was found there)"
+  , csriEcosystem   :: Maybe CMarkdown ? "Item ecosystem (if the match was found there)"
   } deriving (Show, Generic)
 
 instance A.ToJSON CSRItem where

--- a/src/Guide/App.hs
+++ b/src/Guide/App.hs
@@ -1,10 +1,11 @@
-{-# LANGUAGE ConstraintKinds, TypeFamilies #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE TypeFamilies    #-}
 
 {- |
 App module defines types used by the Spock framework.
 
 -}
-module Guide.App 
+module Guide.App
 where
 
 -- hvect
@@ -12,9 +13,9 @@ import Data.HVect
 -- Spock
 import Web.Spock
 
-import Guide.Types.User (User)
-import Guide.Types.Session (GuideData)
 import Guide.ServerStuff (ServerState)
+import Guide.Types.Session (GuideData)
+import Guide.Types.User (User)
 
 -- | Type of connection, currently unused. (Acid-State DB stored in 'ServerState')
 type GuideConn        = ()

--- a/src/Guide/Archival.hs
+++ b/src/Guide/Archival.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications  #-}
 
 
 -- | Methods for working with archive.org. Right now the admin interface
@@ -13,16 +13,15 @@ module Guide.Archival
 )
 where
 
-
 import Imports
 
--- JSON
-import qualified Data.Aeson as A
 -- network
 import Network.HTTP.Client
 
 import Guide.Utils
 
+-- JSON
+import qualified Data.Aeson as A
 
 -- | Get status of a link on archive.org.
 --

--- a/src/Guide/Cache.hs
+++ b/src/Guide/Cache.hs
@@ -14,16 +14,16 @@ where
 
 import Imports
 
--- Concurrent map
-import qualified STMContainers.Map as STMMap
-import qualified Focus
 -- Lucid
 import Lucid.Base
 
-import Guide.Types
 import Guide.State
+import Guide.Types
 import Guide.Utils
 
+-- Concurrent map
+import qualified Focus
+import qualified STMContainers.Map as STMMap
 
 {- | The cache is a (concurrent) map of rendered HTML for various pages and
 pieces of pages.

--- a/src/Guide/Config.hs
+++ b/src/Guide/Config.hs
@@ -17,16 +17,16 @@ where
 import Imports hiding ((.=))
 
 -- JSON
-import Data.Aeson               as Aeson
+import Data.Aeson as Aeson
 import Data.Aeson.Encode.Pretty as Aeson hiding (Config)
--- ByteString
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Lazy as BSL
 -- Default
 import Data.Default
 
 import Guide.Utils
 
+-- ByteString
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as BSL
 
 -- | Site config. Stored in @config.json@.
 data Config = Config {

--- a/src/Guide/Diff.hs
+++ b/src/Guide/Diff.hs
@@ -22,22 +22,21 @@ where
 import Imports
 
 -- Vector
-import qualified Data.Vector as V
 import Data.Vector (Vector)
--- Diffing
-import qualified Data.Patch as PV
 
-import Guide.Diff.Tokenize (tokenize)
 import Guide.Diff.Merge (merge)
+import Guide.Diff.Tokenize (tokenize)
 
+import qualified Data.Patch as PV
+import qualified Data.Vector as V
 
 -- | Result of a diff.
 data Diff = Diff {
   diffContextAbove :: [Text],   -- ^ Context (unchanged parts)
                                 --    above the differing part
   diffContextBelow :: [Text],   -- ^ Context below the differing part
-  diffLeft  :: [DiffChunk],     -- ^ Will contain only 'Deleted' and 'Plain'
-  diffRight :: [DiffChunk]      -- ^ Will contain only 'Added' and 'Plain'
+  diffLeft         :: [DiffChunk],     -- ^ Will contain only 'Deleted' and 'Plain'
+  diffRight        :: [DiffChunk]      -- ^ Will contain only 'Added' and 'Plain'
   }
   deriving (Show)
 
@@ -129,7 +128,7 @@ trimDiff a b =
     -- since chunks in 'a' contain Deleted and Plain, and chunks in 'b'
     -- contain Added and Plain, the only equal parts will be Plain
     getPlain (Plain x) = x
-    getPlain x = error ("trimDiff: impossible: " ++ show x)
+    getPlain x         = error ("trimDiff: impossible: " ++ show x)
 
 ----------------------------------------------------------------------------
 -- Utils

--- a/src/Guide/Diff/Merge.hs
+++ b/src/Guide/Diff/Merge.hs
@@ -13,14 +13,11 @@ where
 
 import Imports
 
--- Text
-import qualified Data.Text as T
--- Vector
-import qualified Data.Vector as V
--- Diffing
-import qualified Data.Patch as PV
-
 import Guide.Diff.Tokenize
+
+import qualified Data.Patch as PV
+import qualified Data.Text as T
+import qualified Data.Vector as V
 
 
 -- | An implementation of a 3-way diff and merge.

--- a/src/Guide/Diff/Tokenize.hs
+++ b/src/Guide/Diff/Tokenize.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE PatternSynonyms   #-}
 
 
 -- | Prepare text for diffing or merging by breaking it into tokens (like
@@ -14,8 +14,9 @@ where
 import Imports
 
 -- Text
-import qualified Data.Text as T
 import Data.List.Split
+
+import qualified Data.Text as T
 
 
 -- | Break text into tokens.

--- a/src/Guide/Handlers.hs
+++ b/src/Guide/Handlers.hs
@@ -1,7 +1,7 @@
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeFamilies        #-}
 
 {- |
 All rest API handlers.
@@ -17,33 +17,31 @@ where
 
 import Imports
 
--- Containers
-import qualified Data.Map as M
-import qualified Data.Set as S
--- Feeds
-import qualified Text.Feed.Types as Feed
-import qualified Text.Feed.Util  as Feed
-import qualified Text.Atom.Feed  as Atom
--- Text
-import qualified Data.Text as T
 -- Web
-import Web.Spock hiding (head, get, renderRoute, text)
-import qualified Web.Spock as Spock
-import Web.Spock.Lucid
 import Lucid hiding (for_)
-import qualified Network.HTTP.Types.Status as HTTP
+import Web.Spock hiding (get, head, renderRoute, text)
+import Web.Spock.Lucid
 
 import Guide.App
-import Guide.ServerStuff
-import Guide.Config
 import Guide.Cache
+import Guide.Config
 import Guide.Diff (merge)
 import Guide.Markdown
+import Guide.Routes
+import Guide.ServerStuff
 import Guide.State
 import Guide.Types
 import Guide.Utils
 import Guide.Views
-import Guide.Routes
+
+import qualified Data.Map as M
+import qualified Data.Set as S
+import qualified Data.Text as T
+import qualified Network.HTTP.Types.Status as HTTP
+import qualified Text.Atom.Feed as Atom
+import qualified Text.Feed.Types as Feed
+import qualified Text.Feed.Util as Feed
+import qualified Web.Spock as Spock
 
 methods :: GuideM ctx ()
 methods = do
@@ -415,7 +413,7 @@ getLoggedInUser :: GuideAction ctx (Maybe User)
 getLoggedInUser = do
   sess <- readSession
   case sess ^. sessionUserID of
-    Nothing -> return Nothing
+    Nothing   -> return Nothing
     Just uid' -> dbQuery $ GetUser uid'
 
 itemToFeedEntry

--- a/src/Guide/JS.hs
+++ b/src/Guide/JS.hs
@@ -1,8 +1,8 @@
-{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE BangPatterns               #-}
+{-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE QuasiQuotes #-}
-{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE QuasiQuotes                #-}
 
 -- TODO: try to make it more type-safe somehow?
 
@@ -17,13 +17,12 @@ module Guide.JS where
 
 import Imports
 
--- Text
-import qualified Data.Text as T
-import qualified Data.Text.Lazy.Builder as B
--- Interpolation
 import NeatInterpolation
 
 import Guide.Utils
+
+import qualified Data.Text as T
+import qualified Data.Text.Lazy.Builder as B
 
 
 -- | Javascript code.

--- a/src/Guide/Main.hs
+++ b/src/Guide/Main.hs
@@ -1,10 +1,10 @@
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE QuasiQuotes         #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE TypeOperators       #-}
 
 {- |
 The main module.
@@ -22,61 +22,59 @@ where
 
 import Imports
 
--- ByteString
-import qualified Data.ByteString as BS
 -- Lists
 import Safe (headDef)
 -- Monads and monad transformers
 import Control.Monad.Morph
 -- Text
-import qualified Data.Text as T
-import qualified Data.Text.IO as T
 import NeatInterpolation (text)
 -- Web
-import Web.Spock hiding (head, get, text)
-import qualified Web.Spock as Spock
+import Lucid hiding (for_)
+import Network.Wai.Middleware.Static (addBase, staticPolicy)
+import Web.Spock hiding (get, head, text)
 import Web.Spock.Config
 import Web.Spock.Lucid
-import Lucid hiding (for_)
-import Network.Wai.Middleware.Static (staticPolicy, addBase)
 -- Spock-digestive
 import Web.Spock.Digestive (runForm)
 -- Highlighting
-import CMark.Highlight (styleToCss, pygments)
--- Monitoring
-import qualified System.Remote.Monitoring as EKG
-import qualified Network.Wai.Metrics      as EKG
-import qualified System.Metrics.Gauge     as EKG.Gauge
+import CMark.Highlight (pygments, styleToCss)
 -- acid-state
 import Data.Acid as Acid
 import Data.SafeCopy as SafeCopy
 import Data.Serialize.Get as Cereal
 -- IO
 import System.IO
-import qualified SlaveThread as Slave
 -- Catching Ctrl-C and termination
 import System.Signal
--- Watching the templates directory
-import qualified System.FSNotify as FSNotify
 -- putStrLn that works well with concurrency
 import Say (say)
 -- HVect
 import Data.HVect hiding (length)
 
-import Guide.App
 import Guide.Api (runApiServer)
-import Guide.ServerStuff
-import Guide.Handlers
+import Guide.App
+import Guide.Cache
 import Guide.Config
+import Guide.Handlers
+import Guide.JS (JS (..), allJSFunctions)
+import Guide.Routes (authRoute, haskellRoute)
+import Guide.ServerStuff
+import Guide.Session
 import Guide.State
 import Guide.Types
-import Guide.Views
-import Guide.Views.Utils (getJS, getCSS, protectForm, getCsrfHeader)
-import Guide.JS (JS(..), allJSFunctions)
 import Guide.Utils
-import Guide.Cache
-import Guide.Session
-import Guide.Routes (authRoute, haskellRoute)
+import Guide.Views
+import Guide.Views.Utils (getCSS, getCsrfHeader, getJS, protectForm)
+
+import qualified Data.ByteString as BS
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+import qualified Network.Wai.Metrics as EKG
+import qualified SlaveThread as Slave
+import qualified System.FSNotify as FSNotify
+import qualified System.Metrics.Gauge as EKG.Gauge
+import qualified System.Remote.Monitoring as EKG
+import qualified Web.Spock as Spock
 
 
 {- Note [acid-state]
@@ -389,7 +387,7 @@ authHook = do
   oldCtx <- getContext
   maybeUser <- getLoggedInUser
   case maybeUser of
-    Nothing -> Spock.text "Not logged in."
+    Nothing   -> Spock.text "Not logged in."
     Just user -> return (user :&: oldCtx)
 
 adminHook :: ListContains n User xs => GuideAction (HVect xs) (HVect (IsAdmin ': xs))

--- a/src/Guide/Markdown.hs
+++ b/src/Guide/Markdown.hs
@@ -1,8 +1,8 @@
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleContexts   #-}
+{-# LANGUAGE FlexibleInstances  #-}
+{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE StandaloneDeriving #-}
 
 
 {- |
@@ -40,25 +40,16 @@ where
 
 import Imports hiding (some)
 
--- Text
-import qualified Data.Text as T
--- ByteString
-import qualified Data.ByteString.Lazy as BSL
-import qualified Data.ByteString as BS
 -- Parsing
 import Text.Megaparsec hiding (State)
 import Text.Megaparsec.Char
--- JSON
-import qualified Data.Aeson as A
 -- HTML
 import Lucid
 import Text.HTML.SanitizeXSS
 -- Containers
 import Data.Tree
-import qualified Data.Set as S
 -- Markdown
 import CMark hiding (Node)
-import qualified CMark as MD
 import CMark.Highlight
 import CMark.Sections
 import ShortcutLinks
@@ -67,6 +58,13 @@ import ShortcutLinks.All (hackage)
 import Data.SafeCopy
 
 import Guide.Utils
+
+import qualified CMark as MD
+import qualified Data.Aeson as A
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as BSL
+import qualified Data.Set as S
+import qualified Data.Text as T
 
 
 data MarkdownInline = MarkdownInline {

--- a/src/Guide/Routes.hs
+++ b/src/Guide/Routes.hs
@@ -1,5 +1,5 @@
+{-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE DataKinds #-}
 
 
 module Guide.Routes
@@ -16,8 +16,8 @@ module Guide.Routes
 ) where
 
 
+import Web.Routing.Combinators (PathState (Open))
 import Web.Spock (Path, (<//>))
-import Web.Routing.Combinators (PathState(Open))
 
 
 haskellRoute :: Path '[] 'Open

--- a/src/Guide/Search.hs
+++ b/src/Guide/Search.hs
@@ -9,14 +9,12 @@ where
 
 import Imports
 
--- Text
-import qualified Data.Text as T
--- Sets
-import qualified Data.Set as S
-
-import Guide.Types
-import Guide.State
 import Guide.Markdown
+import Guide.State
+import Guide.Types
+
+import qualified Data.Set as S
+import qualified Data.Text as T
 
 
 -- | A search result.

--- a/src/Guide/ServerStuff.hs
+++ b/src/Guide/ServerStuff.hs
@@ -1,7 +1,7 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeFamilies      #-}
 
 
 {- |
@@ -36,18 +36,19 @@ where
 import Imports
 
 -- Web
-import Web.Spock hiding (head, get, text)
-import qualified Web.Spock as Spock
-import Web.Routing.Combinators (PathState(..))
+import Web.Routing.Combinators (PathState (..))
+import Web.Spock hiding (get, head, text)
 -- acid-state
 import Data.Acid as Acid
 
+import Guide.Cache
 import Guide.Config
+import Guide.Markdown
 import Guide.State
 import Guide.Types
-import Guide.Cache
 import Guide.Utils
-import Guide.Markdown
+
+import qualified Web.Spock as Spock
 
 
 -- | Global state of the site.

--- a/src/Guide/Session.hs
+++ b/src/Guide/Session.hs
@@ -1,11 +1,11 @@
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TemplateHaskell     #-}
+{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE TypeOperators       #-}
 
 module Guide.Session
 (

--- a/src/Guide/State.hs
+++ b/src/Guide/State.hs
@@ -1,8 +1,8 @@
-{-# LANGUAGE QuasiQuotes #-}
-{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes       #-}
+{-# LANGUAGE TypeFamilies      #-}
 
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
@@ -104,28 +104,27 @@ where
 
 import Imports
 
--- Containers
-import qualified Data.Map as M
-import qualified Data.Set as S
--- Text
-import qualified Data.Text as T
 -- Network
 import Data.IP
 -- acid-state
-import Data.SafeCopy hiding (kind)
-import Data.SafeCopy.Migrate
 import Data.Acid as Acid
 import Data.Acid.Local as Acid
+import Data.SafeCopy hiding (kind)
+import Data.SafeCopy.Migrate
 --
 import Web.Spock.Internal.SessionManager (SessionId)
 
-import Guide.Utils
 import Guide.Markdown
+import Guide.Types.Action
 import Guide.Types.Core
 import Guide.Types.Edit
-import Guide.Types.Action
 import Guide.Types.Session
 import Guide.Types.User
+import Guide.Utils
+
+import qualified Data.Map as M
+import qualified Data.Set as S
+import qualified Data.Text as T
 
 
 {- Note [extending types]
@@ -209,19 +208,19 @@ emptyState = GlobalState {
   _dirty = True }
 
 data GlobalState = GlobalState {
-  _categories :: [Category],
+  _categories        :: [Category],
   _categoriesDeleted :: [Category],
-  _actions :: [(Action, ActionDetails)],
+  _actions           :: [(Action, ActionDetails)],
   -- | Pending edits, newest first
-  _pendingEdits :: [(Edit, EditDetails)],
+  _pendingEdits      :: [(Edit, EditDetails)],
   -- | ID of next edit that will be made
-  _editIdCounter :: Int,
+  _editIdCounter     :: Int,
   -- | Sessions
-  _sessionStore :: Map SessionId GuideSession,
+  _sessionStore      :: Map SessionId GuideSession,
   -- | Users
-  _users :: Map (Uid User) User,
+  _users             :: Map (Uid User) User,
   -- | The dirty bit (needed to choose whether to make a checkpoint or not)
-  _dirty :: Bool }
+  _dirty             :: Bool }
   deriving (Show)
 
 deriveSafeCopySorted 8 'extension ''GlobalState

--- a/src/Guide/Types.hs
+++ b/src/Guide/Types.hs
@@ -13,9 +13,9 @@ module Guide.Types
 )
 where
 
-import Guide.Types.Hue
+import Guide.Types.Action
 import Guide.Types.Core
 import Guide.Types.Edit
-import Guide.Types.Action
-import Guide.Types.User
+import Guide.Types.Hue
 import Guide.Types.Session
+import Guide.Types.User

--- a/src/Guide/Types/Action.hs
+++ b/src/Guide/Types/Action.hs
@@ -30,9 +30,9 @@ import Data.IP
 import Data.SafeCopy hiding (kind)
 import Data.SafeCopy.Migrate
 
-import Guide.Utils
 import Guide.Types.Core
 import Guide.Types.Edit
+import Guide.Utils
 
 
 data Action

--- a/src/Guide/Types/Core.hs
+++ b/src/Guide/Types/Core.hs
@@ -1,9 +1,9 @@
 {-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE FlexibleContexts   #-}
+{-# LANGUAGE FlexibleInstances  #-}
+{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE QuasiQuotes        #-}
+{-# LANGUAGE TypeFamilies       #-}
 
 
 {- |
@@ -59,20 +59,17 @@ where
 
 import Imports
 
--- Text
-import qualified Data.Text as T
--- Containers
-import qualified Data.Set as S
--- JSON
-import qualified Data.Aeson as A
 -- acid-state
 import Data.SafeCopy hiding (kind)
 import Data.SafeCopy.Migrate
 
 import Guide.Markdown
-import Guide.Utils
 import Guide.Types.Hue
+import Guide.Utils
 
+import qualified Data.Aeson as A
+import qualified Data.Set as S
+import qualified Data.Text as T
 
 ----------------------------------------------------------------------------
 -- General notes on code
@@ -92,7 +89,7 @@ For an explanation of deriveSafeCopySorted, see Note [acid-state].
 
 -- | A trait (pro or con). Traits are stored in items.
 data Trait = Trait {
-  _traitUid :: Uid Trait,
+  _traitUid     :: Uid Trait,
   _traitContent :: MarkdownInline }
   deriving (Show, Generic, Data)
 
@@ -145,8 +142,8 @@ deriveSafeCopy 2 'base ''ItemKind_v2
 instance Migrate ItemKind where
   type MigrateFrom ItemKind = ItemKind_v2
   migrate (Library_v2 x) = Library x
-  migrate (Tool_v2 x) = Tool x
-  migrate Other_v2 = Other
+  migrate (Tool_v2 x)    = Tool x
+  migrate Other_v2       = Other
 
 -- | Different kinds of sections inside items. This type is only used for
 -- '_categoryEnabledSections'.
@@ -219,33 +216,33 @@ deriveSafeCopySimple 1 'base ''CategoryStatus_v1
 
 instance Migrate CategoryStatus where
   type MigrateFrom CategoryStatus = CategoryStatus_v1
-  migrate CategoryStub_v1 = CategoryStub
-  migrate CategoryWIP_v1 = CategoryWIP
+  migrate CategoryStub_v1       = CategoryStub
+  migrate CategoryWIP_v1        = CategoryWIP
   migrate CategoryMostlyDone_v1 = CategoryFinished
-  migrate CategoryFinished_v1 = CategoryFinished
+  migrate CategoryFinished_v1   = CategoryFinished
 
 -- | A category
 data Category = Category {
-  _categoryUid          :: Uid Category,
-  _categoryTitle        :: Text,
+  _categoryUid             :: Uid Category,
+  _categoryTitle           :: Text,
   -- | When the category was created
-  _categoryCreated      :: UTCTime,
+  _categoryCreated         :: UTCTime,
   -- | The “grandcategory” of the category (“meta”, “basics”, etc)
-  _categoryGroup_       :: Text,
-  _categoryStatus       :: CategoryStatus,
-  _categoryNotes        :: MarkdownBlock,
+  _categoryGroup_          :: Text,
+  _categoryStatus          :: CategoryStatus,
+  _categoryNotes           :: MarkdownBlock,
   -- | Items stored in the category
-  _categoryItems        :: [Item],
+  _categoryItems           :: [Item],
   -- | Items that were deleted from the category. We keep them here to make
   -- it easier to restore them
-  _categoryItemsDeleted :: [Item],
+  _categoryItemsDeleted    :: [Item],
   -- | Enabled sections in this category. E.g, if this set contains
   -- 'ItemNotesSection', then notes will be shown for each item
   _categoryEnabledSections :: Set ItemSection,
   -- | All groups of items belonging to the category, as well as their
   -- colors. Storing colors explicitly lets us keep colors consistent when
   -- all items in a group are deleted
-  _categoryGroups :: Map Text Hue
+  _categoryGroups          :: Map Text Hue
   }
   deriving (Show, Generic, Data)
 

--- a/src/Guide/Types/Edit.hs
+++ b/src/Guide/Types/Edit.hs
@@ -25,8 +25,8 @@ import Data.IP
 import Data.SafeCopy hiding (kind)
 import Data.SafeCopy.Migrate
 
-import Guide.Utils
 import Guide.Types.Core
+import Guide.Utils
 
 
 -- | Edits made by users. It should always be possible to undo an edit.
@@ -37,31 +37,31 @@ data Edit
       editCategoryTitle :: Text,
       editCategoryGroup :: Text }
   | Edit'AddItem {
-      editCategoryUid   :: Uid Category,
-      editItemUid       :: Uid Item,
-      editItemName      :: Text }
+      editCategoryUid :: Uid Category,
+      editItemUid     :: Uid Item,
+      editItemName    :: Text }
   | Edit'AddPro {
-      editItemUid       :: Uid Item,
-      editTraitId       :: Uid Trait,
-      editTraitContent  :: Text }
+      editItemUid      :: Uid Item,
+      editTraitId      :: Uid Trait,
+      editTraitContent :: Text }
   | Edit'AddCon {
-      editItemUid       :: Uid Item,
-      editTraitId       :: Uid Trait,
-      editTraitContent  :: Text }
+      editItemUid      :: Uid Item,
+      editTraitId      :: Uid Trait,
+      editTraitContent :: Text }
 
   -- Change category properties
   | Edit'SetCategoryTitle {
-      editCategoryUid       :: Uid Category,
-      editCategoryTitle     :: Text,
-      editCategoryNewTitle  :: Text }
+      editCategoryUid      :: Uid Category,
+      editCategoryTitle    :: Text,
+      editCategoryNewTitle :: Text }
   | Edit'SetCategoryGroup {
-      editCategoryUid       :: Uid Category,
-      editCategoryGroup     :: Text,
-      editCategoryNewGroup  :: Text }
+      editCategoryUid      :: Uid Category,
+      editCategoryGroup    :: Text,
+      editCategoryNewGroup :: Text }
   | Edit'SetCategoryNotes {
-      editCategoryUid       :: Uid Category,
-      editCategoryNotes     :: Text,
-      editCategoryNewNotes  :: Text }
+      editCategoryUid      :: Uid Category,
+      editCategoryNotes    :: Text,
+      editCategoryNewNotes :: Text }
   | Edit'SetCategoryStatus {
       editCategoryUid       :: Uid Category,
       editCategoryStatus    :: CategoryStatus,
@@ -73,34 +73,34 @@ data Edit
 
   -- Change item properties
   | Edit'SetItemName {
-      editItemUid            :: Uid Item,
-      editItemName           :: Text,
-      editItemNewName        :: Text }
+      editItemUid     :: Uid Item,
+      editItemName    :: Text,
+      editItemNewName :: Text }
   | Edit'SetItemLink {
-      editItemUid            :: Uid Item,
-      editItemLink           :: Maybe Url,
-      editItemNewLink        :: Maybe Url }
+      editItemUid     :: Uid Item,
+      editItemLink    :: Maybe Url,
+      editItemNewLink :: Maybe Url }
   | Edit'SetItemGroup {
-      editItemUid            :: Uid Item,
-      editItemGroup          :: Maybe Text,
-      editItemNewGroup       :: Maybe Text }
+      editItemUid      :: Uid Item,
+      editItemGroup    :: Maybe Text,
+      editItemNewGroup :: Maybe Text }
   | Edit'SetItemKind {
-      editItemUid            :: Uid Item,
-      editItemKind           :: ItemKind,
-      editItemNewKind        :: ItemKind }
+      editItemUid     :: Uid Item,
+      editItemKind    :: ItemKind,
+      editItemNewKind :: ItemKind }
 
   | Edit'SetItemDescription {
       editItemUid            :: Uid Item,
       editItemDescription    :: Text,
       editItemNewDescription :: Text }
   | Edit'SetItemNotes {
-      editItemUid            :: Uid Item,
-      editItemNotes          :: Text,
-      editItemNewNotes       :: Text }
+      editItemUid      :: Uid Item,
+      editItemNotes    :: Text,
+      editItemNewNotes :: Text }
   | Edit'SetItemEcosystem {
-      editItemUid            :: Uid Item,
-      editItemEcosystem      :: Text,
-      editItemNewEcosystem   :: Text }
+      editItemUid          :: Uid Item,
+      editItemEcosystem    :: Text,
+      editItemNewEcosystem :: Text }
 
   -- Change trait properties
   | Edit'SetTraitContent {
@@ -111,15 +111,15 @@ data Edit
 
   -- Delete
   | Edit'DeleteCategory {
-      editCategoryUid       :: Uid Category,
-      editCategoryPosition  :: Int }
+      editCategoryUid      :: Uid Category,
+      editCategoryPosition :: Int }
   | Edit'DeleteItem {
-      editItemUid           :: Uid Item,
-      editItemPosition      :: Int }
+      editItemUid      :: Uid Item,
+      editItemPosition :: Int }
   | Edit'DeleteTrait {
-      editItemUid           :: Uid Item,
-      editTraitUid          :: Uid Trait,
-      editTraitPosition     :: Int }
+      editItemUid       :: Uid Item,
+      editTraitUid      :: Uid Trait,
+      editTraitPosition :: Int }
 
   -- Other
   | Edit'MoveItem {

--- a/src/Guide/Types/Hue.hs
+++ b/src/Guide/Types/Hue.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE TemplateHaskell    #-}
+{-# LANGUAGE TypeFamilies       #-}
 
 
 {- |
@@ -19,10 +19,9 @@ where
 
 import Imports
 
--- JSON
-import qualified Data.Aeson as A
--- acid-state
 import Data.SafeCopy hiding (kind)
+
+import qualified Data.Aeson as A
 
 
 data Hue = NoHue | Hue Int
@@ -31,7 +30,7 @@ data Hue = NoHue | Hue Int
 deriveSafeCopySimple 1 'extension ''Hue
 
 instance A.ToJSON Hue where
-  toJSON NoHue = A.toJSON (0 :: Int)
+  toJSON NoHue   = A.toJSON (0 :: Int)
   toJSON (Hue n) = A.toJSON n
 
 data Hue_v0 = NoHue_v0 | Hue_v0 Int
@@ -40,7 +39,7 @@ deriveSafeCopy 0 'base ''Hue_v0
 
 instance Migrate Hue where
   type MigrateFrom Hue = Hue_v0
-  migrate NoHue_v0 = NoHue
+  migrate NoHue_v0   = NoHue
   migrate (Hue_v0 i) = Hue i
 
 instance Show Hue where

--- a/src/Guide/Types/Session.hs
+++ b/src/Guide/Types/Session.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE TypeFamilies      #-}
 
 
 module Guide.Types.Session
@@ -22,18 +22,16 @@ where
 
 import Imports
 
--- Spock
-import Web.Spock.Internal.SessionManager (SessionId)
-import qualified Web.Spock.Internal.SessionManager as Spock
--- Spock Session wrapper
-import Data.Time.Clock ( UTCTime(..) )
-import qualified Data.Text as T
--- acid-state
 import Data.SafeCopy hiding (kind)
 import Data.SafeCopy.Migrate
+import Data.Time.Clock (UTCTime (..))
+import Web.Spock.Internal.SessionManager (SessionId)
 
-import Guide.Utils
 import Guide.Types.User
+import Guide.Utils
+
+import qualified Data.Text as T
+import qualified Web.Spock.Internal.SessionManager as Spock
 
 
 type SpockSession conn st = Spock.Session conn GuideData st
@@ -53,10 +51,10 @@ emptyGuideData = GuideData {
   _sessionUserID = Nothing }
 
 data GuideSession = GuideSession {
-  _sess_id :: !SessionId,
-  _sess_csrfToken :: !T.Text,
+  _sess_id         :: !SessionId,
+  _sess_csrfToken  :: !T.Text,
   _sess_validUntil :: !UTCTime,
-  _sess_data :: !GuideData }
+  _sess_data       :: !GuideData }
   deriving (Show, Eq)
 
 deriveSafeCopySorted 0 'base ''GuideSession

--- a/src/Guide/Types/User.hs
+++ b/src/Guide/Types/User.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies       #-}
 
 {- |
 A type for users. Currently unused.
@@ -28,22 +28,22 @@ import Imports
 import Data.SafeCopy hiding (kind)
 import Data.SafeCopy.Migrate
 -- scrypt
-import Crypto.Scrypt (Pass (..), EncryptedPass (..), encryptPassIO', getEncryptedPass, verifyPass')
+import Crypto.Scrypt (EncryptedPass (..), Pass (..), encryptPassIO', getEncryptedPass, verifyPass')
 
 import Guide.Utils
 
 
 data User = User {
   -- | Unique, pseudorandom identifier for user.
-  _userID          :: Uid User,
+  _userID       :: Uid User,
   -- | Unique username for user.
-  _userName        :: Text,
+  _userName     :: Text,
   -- | Unique email address for user.
-  _userEmail       :: Text,
+  _userEmail    :: Text,
   -- | Scrypt generated password field, contains salt + hash.
-  _userPassword    :: Maybe ByteString,
+  _userPassword :: Maybe ByteString,
   -- | Flag set if user is an administrator.
-  _userIsAdmin     :: Bool
+  _userIsAdmin  :: Bool
   }
   deriving (Show)
 
@@ -64,10 +64,10 @@ makeUser username email password = do
 
 -- | Verifies a given password corresponds to a user's encrypted password.
 verifyUser :: User -> ByteString -> Bool
-verifyUser user password = 
+verifyUser user password =
   case user ^. userPassword of
     Just encPass -> verifyPass' (Pass password) (EncryptedPass encPass)
-    Nothing -> False
+    Nothing      -> False
 
 -- | Looks at two users, and returns true if all unique fields are different.
 canCreateUser :: User -> User -> Bool

--- a/src/Guide/Utils.hs
+++ b/src/Guide/Utils.hs
@@ -1,11 +1,11 @@
-{-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE QuasiQuotes #-}
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveDataTypeable         #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE QuasiQuotes                #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE TypeFamilies               #-}
 
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
@@ -76,43 +76,41 @@ import Imports
 
 -- Monads and monad transformers
 import Control.Monad.Catch
--- Containers
-import qualified Data.Set as S
 -- Randomness
 import System.Random
--- Text
-import qualified Data.Text as T
--- Bytestring
-import qualified Data.ByteString.Lazy as BSL
--- JSON
-import qualified Data.Aeson as A
-import qualified Data.Aeson.Text as A
-import qualified Data.Aeson.Types as A
-import qualified Data.Aeson.Internal as A
-import qualified Data.Aeson.Encode.Pretty as A
 -- Network
-import qualified Network.Socket as Network
 import Data.IP
 -- Web
 import Lucid hiding (for_)
-import Web.Spock as Spock
 import Text.HTML.SanitizeXSS (sanitaryURI)
 import Web.HttpApiData
-import qualified Network.Wai as Wai
+import Web.Spock as Spock
 -- Feeds
-import qualified Text.Atom.Feed        as Atom
-import qualified Text.Atom.Feed.Export as Atom
-import qualified Text.XML              as XMLC
-import qualified Data.XML.Types        as XML
 -- acid-state
 import Data.SafeCopy
 -- Template Haskell
 import Language.Haskell.TH
+-- needed for parsing urls
+import Network.HTTP.Types (Query, parseQuery)
+
+import qualified Data.Aeson as A
+import qualified Data.Aeson.Encode.Pretty as A
+import qualified Data.Aeson.Internal as A
+import qualified Data.Aeson.Text as A
+import qualified Data.Aeson.Types as A
+import qualified Data.ByteString.Lazy as BSL
+import qualified Data.Set as S
+import qualified Data.Text as T
+import qualified Data.XML.Types as XML
+import qualified Network.Socket as Network
+import qualified Network.Wai as Wai
+import qualified Text.Atom.Feed as Atom
+import qualified Text.Atom.Feed.Export as Atom
+import qualified Text.XML as XMLC
+
 -- needed for 'sanitiseUrl'
 import qualified Codec.Binary.UTF8.String as UTF8
 import qualified Network.URI as URI
--- needed for parsing urls
-import Network.HTTP.Types (Query, parseQuery)
 
 ----------------------------------------------------------------------------
 -- Lists
@@ -121,12 +119,12 @@ import Network.HTTP.Types (Query, parseQuery)
 -- | Move the -1st element that satisfies the predicate- up.
 moveUp :: (a -> Bool) -> [a] -> [a]
 moveUp p (x:y:xs) = if p y then y : x : xs else x : moveUp p (y:xs)
-moveUp _ xs = xs
+moveUp _ xs       = xs
 
 -- | Move the -1st element that satisfies the predicate- down.
 moveDown :: (a -> Bool) -> [a] -> [a]
 moveDown p (x:y:xs) = if p x then y : x : xs else x : moveDown p (y:xs)
-moveDown _ xs = xs
+moveDown _ xs       = xs
 
 -- | Delete the first element that satisfies the predicate (if such an
 -- element is present).
@@ -302,7 +300,7 @@ deriveSafeCopySimple 0 'base ''IP
 sockAddrToIP :: Network.SockAddr -> Maybe IP
 sockAddrToIP (Network.SockAddrInet  _   x)   = Just (IPv4 (fromHostAddress x))
 sockAddrToIP (Network.SockAddrInet6 _ _ x _) = Just (IPv6 (fromHostAddress6 x))
-sockAddrToIP _ = Nothing
+sockAddrToIP _                               = Nothing
 
 ----------------------------------------------------------------------------
 -- Uid

--- a/src/Guide/Views.hs
+++ b/src/Guide/Views.hs
@@ -1,9 +1,9 @@
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE TypeApplications    #-}
-{-# LANGUAGE QuasiQuotes         #-}
-{-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ExplicitForAll      #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE QuasiQuotes         #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
 
 
 {- |
@@ -31,15 +31,12 @@ where
 
 -- Reexporting children modules
 import Guide.Views.Auth as X
-import Guide.Views.Page as X
-import Guide.Views.Item as X
 import Guide.Views.Category as X
+import Guide.Views.Item as X
+import Guide.Views.Page as X
 
 import Imports
 
--- Text
-import qualified Data.Text as T
-import qualified Data.Text.IO as T
 import NeatInterpolation
 -- Web
 import Lucid hiding (for_)
@@ -47,30 +44,32 @@ import Lucid hiding (for_)
 import Data.IP
 import Network.HTTP.Client
 import Network.HTTP.Client.TLS
-import Network.HTTP.Types.Status (Status(..))
+import Network.HTTP.Types.Status (Status (..))
 import Network.URI (isURI)
 -- Time
 import Data.Time.Format.Human
--- Mustache (templates)
-import qualified Data.Aeson as A
--- CMark
-import qualified CMark as MD
 -- Generic traversal (for finding links in content)
 import Data.Generics.Uniplate.Data (universeBi)
 
+import Guide.Archival
+import Guide.Cache
 import Guide.Config
+import Guide.Diff hiding (DiffChunk)
+import Guide.JS (JS (..))
+import Guide.Markdown
+import Guide.Search
 import Guide.State
 import Guide.Types
-import Guide.Search
 import Guide.Utils
-import Guide.JS (JS(..))
-import qualified Guide.JS as JS
-import Guide.Markdown
-import Guide.Archival
-import Guide.Diff hiding (DiffChunk)
-import qualified Guide.Diff as Diff
-import Guide.Cache
 import Guide.Views.Utils
+
+import qualified CMark as MD
+import qualified Data.Aeson as A
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+
+import qualified Guide.Diff as Diff
+import qualified Guide.JS as JS
 
 {- Note [autosize]
 ~~~~~~~~~~~~~~~~~~
@@ -576,7 +575,7 @@ renderHaskellRoot globalState mbSearchQuery =
       autocomplete_ "off",
       onEnter $ JS.addCategoryAndRedirect [inputValue] ]
     case mbSearchQuery of
-      Nothing -> renderCategoryList (globalState^.categories)
+      Nothing     -> renderCategoryList (globalState^.categories)
       Just query' -> renderSearchResults (search query' globalState)
     -- TODO: maybe add a button like “give me random category that is
     -- unfinished”
@@ -809,11 +808,11 @@ data LinkStatus = OK | Unparseable | Broken String deriving Show
 
 data LinkInfo = LinkInfo {
   -- | Link itself
-  linkUrl :: Url,
+  linkUrl            :: Url,
   -- | A description of where the link is in Guide
-  linkLocation :: Text,
+  linkLocation       :: Text,
   -- | Link status (ok, unparseable, etc)
-  linkStatus :: LinkStatus,
+  linkStatus         :: LinkStatus,
   -- | Link status on archive.org (if archive.org is available)
   linkArchivalStatus :: Either String ArchivalStatus
   }

--- a/src/Guide/Views/Auth.hs
+++ b/src/Guide/Views/Auth.hs
@@ -7,5 +7,5 @@ module Guide.Views.Auth
 )
 where
 
-import Guide.Views.Auth.Register as X
 import Guide.Views.Auth.Login as X
+import Guide.Views.Auth.Register as X

--- a/src/Guide/Views/Auth/Login.hs
+++ b/src/Guide/Views/Auth/Login.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 
 {- |
@@ -13,15 +13,15 @@ import Imports
 -- digestive-functors
 import Text.Digestive
 -- lucid
-import Lucid hiding (for_)
-import Guide.Views.Page
-import Guide.Views.Utils
 import Guide.Config
 import Guide.Types.User
+import Guide.Views.Page
+import Guide.Views.Utils
+import Lucid hiding (for_)
 
 -- | Fields used by this form.
 data Login = Login {
-  loginEmail :: Text,
+  loginEmail        :: Text,
   loginUserPassword :: Text }
 
 -- | Creates a digestive functor over the fields in 'UserRegistration'

--- a/src/Guide/Views/Auth/Register.hs
+++ b/src/Guide/Views/Auth/Register.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -fno-warn-name-shadowing #-}
 
 {- |
@@ -15,16 +15,16 @@ import Text.Digestive
 -- lucid
 import Lucid hiding (for_)
 
-import Guide.Views.Page
-import Guide.Views.Utils
 import Guide.Config
 import Guide.Types.User
+import Guide.Views.Page
+import Guide.Views.Utils
 
 -- | Fields used by this form/view.
 data UserRegistration = UserRegistration {
-  registerUserName  :: Text,
-  registerUserEmail :: Text,
-  registerUserPassword :: Text,
+  registerUserName               :: Text,
+  registerUserEmail              :: Text,
+  registerUserPassword           :: Text,
   registerUserPasswordValidation :: Text }
 
 -- | Creates a digestive functor over the fields in 'UserRegistration'
@@ -38,7 +38,7 @@ registerForm = UserRegistration
 -- | Render input elements for a 'UserRegistration'
 -- Note: This does not include the 'Form' element.
 --
--- Use 'Guide.Server.protectForm' to render the appropriate form element with CSRF protection. 
+-- Use 'Guide.Server.protectForm' to render the appropriate form element with CSRF protection.
 registerFormView :: MonadIO m => View (HtmlT m ()) -> HtmlT m ()
 registerFormView view = do
   div_ $ do
@@ -68,11 +68,11 @@ registerView :: (MonadIO m) => User -> HtmlT m ()
 registerView user = do
   div_ $ do
     -- TODO: Make nicer.
-    "You are registered and logged in as " 
+    "You are registered and logged in as "
     toHtml (user ^. userName)
 
 renderRegister :: (MonadIO m, MonadReader Config m) => HtmlT m () -> HtmlT m ()
 renderRegister content = do
-  renderPage $ 
+  renderPage $
     pageDef & pageTitle .~ "Aelve Guide"
             & pageContent .~ content

--- a/src/Guide/Views/Category.hs
+++ b/src/Guide/Views/Category.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 
@@ -22,19 +22,19 @@ where
 
 import Imports
 
--- Text
-import qualified Data.Text.IO as T
 -- HTML
 import Lucid hiding (for_)
 
-import Guide.Types.Core
-import qualified Guide.JS as JS
 import Guide.Cache
 import Guide.Markdown
+import Guide.Types.Core
 import Guide.Utils
-import Guide.Views.Utils
 import Guide.Views.Item
+import Guide.Views.Utils
 
+import qualified Data.Text.IO as T
+
+import qualified Guide.JS as JS
 
 ----------------------------------------------------------------------------
 -- Main functions

--- a/src/Guide/Views/Item.hs
+++ b/src/Guide/Views/Item.hs
@@ -30,25 +30,23 @@ where
 import Imports
 
 -- Containers
-import qualified Data.Map as M
 import Data.Tree
--- Text
-import qualified Data.Text.IO as T
 -- HTML
 import Lucid hiding (for_)
--- JSON
-import qualified Data.Aeson as A
--- Markdown
-import qualified CMark as MD
 
-import Guide.Types.Core
-import Guide.JS (JS(..))
-import qualified Guide.JS as JS
 import Guide.Cache
+import Guide.JS (JS (..))
 import Guide.Markdown
+import Guide.Types.Core
 import Guide.Utils
 import Guide.Views.Utils
 
+import qualified CMark as MD
+import qualified Data.Aeson as A
+import qualified Data.Map as M
+import qualified Data.Text.IO as T
+
+import qualified Guide.JS as JS
 
 ----------------------------------------------------------------------------
 -- Main functions
@@ -119,8 +117,8 @@ renderItemInfo cat item = cached (CacheItemInfo (item^.uid)) $ do
   let itemkindname :: Text
       itemkindname = case item^.kind of
         Library{} -> "library"
-        Tool{} -> "tool"
-        Other{} -> "other"
+        Tool{}    -> "tool"
+        Other{}   -> "other"
   mustache "item-info" $ A.object [
     "category" A..= cat,
     "item" A..= item,

--- a/src/Guide/Views/Page.hs
+++ b/src/Guide/Views/Page.hs
@@ -1,7 +1,7 @@
-{-# LANGUAGE QuasiQuotes #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes       #-}
 
 
 {- |
@@ -31,22 +31,21 @@ where
 
 import Imports
 
--- Text
-import qualified Data.Text as T
-import NeatInterpolation
--- Web
 import Lucid hiding (for_)
+import NeatInterpolation
 
 import Guide.Config
+import Guide.JS (JS (..))
+import Guide.Utils
+import Guide.Views.Utils
 -- import Guide.State
 -- import Guide.Types
-import Guide.Utils
-import Guide.JS (JS(..))
-import qualified Guide.JS as JS
 -- import Guide.Markdown
 -- import Guide.Cache
 
-import Guide.Views.Utils
+import qualified Data.Text as T
+
+import qualified Guide.JS as JS
 
 
 -- |Record for the parts of a page, for rendering in a standard template.
@@ -54,27 +53,27 @@ data Page m = Page {
     -- | Title for the root of a site.
     -- By default displays before the page name in the <title>
     -- and header of page, e.g. "Aelve Guide"
-    _pageTitle :: Text,
+    _pageTitle     :: Text,
     -- | Name of a particular page.
     -- Displays after the title, e.g. "Haskell" or "Login"
-    _pageName :: Maybe Text,
+    _pageName      :: Maybe Text,
     -- | Url accessed by clicking header text.
     _pageHeaderUrl :: Url,
     -- | Subtitle element.
     -- By default displays immediately below the "Title | Name" header.
-    _pageSubtitle :: Page m -> HtmlT m (),
+    _pageSubtitle  :: Page m -> HtmlT m (),
     -- | Scripts to load in the <head> tag.
-    _pageScripts :: [Url],
+    _pageScripts   :: [Url],
     -- | Stylesheets to load in the <head> tag.
-    _pageStyles :: [Url],
+    _pageStyles    :: [Url],
     -- | Contents of <head> tag
-    _pageHeadTag :: Page m -> HtmlT m (),
+    _pageHeadTag   :: Page m -> HtmlT m (),
     -- | Header element to display at the top of the body element.
-    _pageHeader :: Page m -> HtmlT m (),
+    _pageHeader    :: Page m -> HtmlT m (),
     -- | Content element to display in the center of the template.
-    _pageContent :: HtmlT m (),
+    _pageContent   :: HtmlT m (),
     -- | Footer element to display at bottom of the body element.
-    _pageFooter :: Page m -> HtmlT m ()
+    _pageFooter    :: Page m -> HtmlT m ()
   }
 
 makeLenses ''Page
@@ -105,7 +104,7 @@ pageDef = Page {
     _pageFooter = footerDef
   }
 
-subtitleDef 
+subtitleDef
   :: MonadIO m
   => Page m
   -> HtmlT m ()
@@ -119,7 +118,7 @@ subtitleDef _page = pure ()
       Just l  -> " • " >> mkLink "discuss the site" l
   -}
 
-headTagDef 
+headTagDef
   :: (MonadIO m, MonadReader Config m)
   => Page m
   -> HtmlT m ()
@@ -159,7 +158,7 @@ headTagDef page = do
     document.head.appendChild(sheet);
     |]
 
-headerDef 
+headerDef
   :: MonadIO m
   => Page m
   -> HtmlT m ()
@@ -167,13 +166,13 @@ headerDef page = do
   div_ $ do
     let nameHtml = case _pageName page of
           Just name -> span_ (" | " >> toHtml name)
-          Nothing -> mempty
+          Nothing   -> mempty
     h1_ $ mkLink (toHtml (_pageTitle page) >> nameHtml) (_pageHeaderUrl page)
     (_pageSubtitle page) page
   div_ [class_ "auth-link-container"] $ do
     a_ [href_ "/auth"] "login/logout"
 
-footerDef 
+footerDef
   :: MonadIO m
   => Page m
   -> HtmlT m ()

--- a/src/Guide/Views/Utils.hs
+++ b/src/Guide/Views/Utils.hs
@@ -1,6 +1,6 @@
+{-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE QuasiQuotes       #-}
 
 {- |
 Various HTML utils, Mustache utils, etc.
@@ -65,12 +65,6 @@ import Web.Spock
 import Web.Spock.Config
 -- Lists
 import Data.List.Split
--- Containers
-import qualified Data.Map as M
--- import Data.Tree
--- Text
-import qualified Data.Text as T
-import qualified Data.Text.IO as T
 -- digestive-functors
 import Text.Digestive (View)
 -- import NeatInterpolation
@@ -78,7 +72,6 @@ import Text.Digestive (View)
 import Lucid hiding (for_)
 import Lucid.Base (makeAttribute)
 -- Files
-import qualified System.FilePath.Find as F
 -- -- Network
 -- import Data.IP
 -- -- Time
@@ -86,25 +79,32 @@ import qualified System.FilePath.Find as F
 -- -- Markdown
 -- import qualified CMark as MD
 -- Mustache (templates)
-import Text.Mustache.Plus
-import qualified Data.Aeson as A
-import qualified Data.ByteString.Lazy.Char8 as BS
-import qualified Data.Semigroup as Semigroup
-import qualified Data.List.NonEmpty as NonEmpty
 import Text.Megaparsec
 import Text.Megaparsec.Char
+import Text.Mustache.Plus
 
 import Guide.App
--- import Guide.Config
--- import Guide.State
+import Guide.JS (JQuerySelector, JS (..))
+import Guide.Markdown
 import Guide.Types
 import Guide.Utils
-import Guide.JS (JS(..), JQuerySelector)
-import qualified Guide.JS as JS
-import Guide.Markdown
+-- import Guide.Config
+-- import Guide.State
 -- import Guide.Cache
 
 import Guide.Views.Utils.Input
+
+import qualified Data.Aeson as A
+import qualified Data.ByteString.Lazy.Char8 as BS
+import qualified Data.List.NonEmpty as NonEmpty
+import qualified Data.Map as M
+import qualified Data.Semigroup as Semigroup
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+import qualified System.FilePath.Find as F
+
+import qualified Guide.JS as JS
+
 
 -- | Add a script that does something on page load.
 onPageLoad :: Monad m => JS -> HtmlT m ()
@@ -230,7 +230,7 @@ smallMarkdownEditor rows (view mdSource -> src) submit mbCancel instr mbPlacehol
                          map (vBind "placeholder") (maybeToList mbPlaceholder) ++
                          [vOn "submit-edit" (submit (JS "$event"))] ++
                          case mbCancel of {
-                           Nothing -> [vBind "allow-cancel" False];
+                           Nothing     -> [vBind "allow-cancel" False];
                            Just cancel -> [vOn "cancel-edit" cancel]; })
     (pure ())
   script_ (format "new Vue({el: '#{}'});" editorUid)
@@ -335,7 +335,7 @@ readWidget fp = liftIO $ do
                       T.length line >= 20
   let go (x:y:[]) = [(T.strip (last x), unlinesSection y)]
       go (x:y:xs) = (T.strip (last x), unlinesSection (init y)) : go (y : xs)
-      go _ = error $ "View.readWidget: couldn't read " ++ fp
+      go _        = error $ "View.readWidget: couldn't read " ++ fp
   let sections = go (splitWhen isDivide (T.lines s))
   let sectionTypeP :: Parsec Void Text SectionType
       sectionTypeP = choice [

--- a/src/Guide/Views/Utils/Input.hs
+++ b/src/Guide/Views/Utils/Input.hs
@@ -5,31 +5,30 @@
 Lucid rendering for inputs and form fields.
 -}
 module Guide.Views.Utils.Input
-( 
-  inputText, 
-  inputTextArea, 
-  inputPassword, 
-  inputHidden, 
-  inputSelect, 
-  inputRadio, 
-  inputCheckbox, 
-  inputFile, 
-  inputSubmit, 
-  label, 
-  form, 
-  errorList, 
-  childErrorList, 
+(
+  inputText,
+  inputTextArea,
+  inputPassword,
+  inputHidden,
+  inputSelect,
+  inputRadio,
+  inputCheckbox,
+  inputFile,
+  inputSubmit,
+  label,
+  form,
+  errorList,
+  childErrorList,
   ifSingleton
 )
 where
 
 import Imports hiding (for_)
 
-import           Control.Monad               (forM_, when)
-import           Data.Text                   (Text, pack)
-import           Lucid
-
-import           Text.Digestive.View
+import Control.Monad (forM_, when)
+import Data.Text (Text, pack)
+import Lucid
+import Text.Digestive.View
 
 ifSingleton :: Bool -> a -> [a]
 ifSingleton False _ = []
@@ -173,5 +172,5 @@ errorList ref view = case errors ref view of
 childErrorList :: Monad m => Text -> View (HtmlT m ()) -> HtmlT m ()
 childErrorList ref view = case childErrors ref view of
     []   -> mempty
-    errs -> ul_ [class_ "digestive-functors-error-list"] $ forM_ errs $ \e -> 
+    errs -> ul_ [class_ "digestive-functors-error-list"] $ forM_ errs $ \e ->
               li_ [class_ "digestive-functors-error"] e

--- a/src/Imports.hs
+++ b/src/Imports.hs
@@ -14,38 +14,37 @@ module Imports
 where
 
 
-import           BasePrelude            as X
-  hiding (Category, GeneralCategory, lazy, Handler, diff, option)
+import BasePrelude as X hiding (Category, GeneralCategory, Handler, diff, lazy, option)
 -- Conversions
-import           To                     as X
+import To as X
 -- Lists
-import           Data.List.Extra        as X (dropEnd, takeEnd)
-import           Data.List.Index        as X
+import Data.List.Extra as X (dropEnd, takeEnd)
+import Data.List.Index as X
 -- Lenses
-import           Lens.Micro.Platform    as X
+import Lens.Micro.Platform as X
 -- Monads and monad transformers
-import           Control.Monad.Reader   as X
-import           Control.Monad.State    as X
-import           Control.Monad.Except   as X
+import Control.Monad.Except as X
+import Control.Monad.Reader as X
+import Control.Monad.State as X
 -- Common types
-import           Data.ByteString        as X (ByteString)
-import           Data.Map               as X (Map)
-import           Data.Set               as X (Set)
-import           Data.Text              as X (Text)
+import Data.ByteString as X (ByteString)
+import Data.Map as X (Map)
+import Data.Set as X (Set)
+import Data.Text as X (Text)
 -- Time
-import           Data.Time              as X
+import Data.Time as X
 -- Files
-import           System.Directory       as X
-import           System.FilePath        as X
+import System.Directory as X
+import System.FilePath as X
 -- Deepseq
-import           Control.DeepSeq        as X
+import Control.DeepSeq as X
 -- Hashable
-import           Data.Hashable          as X
+import Data.Hashable as X
 -- Lazy
-import qualified Data.ByteString.Lazy   as BSL
-import qualified Data.Text.Lazy         as TL
+import qualified Data.ByteString.Lazy as BSL
+import qualified Data.Text.Lazy as TL
 -- Formatting
-import           Fmt                    as X
+import Fmt as X
 
 
 type LByteString = BSL.ByteString

--- a/src/To.hs
+++ b/src/To.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE TypeSynonymInstances, GADTs #-}
+{-# LANGUAGE GADTs                #-}
+{-# LANGUAGE TypeSynonymInstances #-}
 
 
 module To
@@ -16,8 +17,9 @@ import Prelude
 import Data.Text
 import Data.Text.Encoding
 import Data.Text.Encoding.Error
-import qualified Data.Text.Lazy.Builder as B
 import Data.Text.Lazy.Builder (Builder)
+
+import qualified Data.Text.Lazy.Builder as B
 
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Encoding as TL
@@ -25,8 +27,8 @@ import qualified Data.Text.Lazy.Encoding as TL
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL
 
-import qualified Data.ByteString.UTF8 as UTF8
 import qualified Data.ByteString.Lazy.UTF8 as UTF8L
+import qualified Data.ByteString.UTF8 as UTF8
 
 
 class ToText t where

--- a/src/site/Main.hs
+++ b/src/site/Main.hs
@@ -1,7 +1,8 @@
 module Main where
 
+import Prelude (IO)
+
 import qualified Guide.Main
-import           Prelude      (IO)
 
 main :: IO ()
 main = Guide.Main.main


### PR DESCRIPTION
I've applied `stylish-haskell` to every Haskell module and grouped imports into sections.

We're going to slowly follow _explicit imports_ policy but if I did this in this PR, I would die. So let's make explicit imports lazily, but at least we shouldn't expect more massive changes by `stylish-haskell`.