### PR TITLE
Use rounded corners for item boxes.

### DIFF
--- a/templates/css.widget
+++ b/templates/css.widget
@@ -250,6 +250,8 @@ body {
 
 .item-body {
   padding-top: 5px;
+  border-bottom-left-radius: 5px;
+  border-bottom-right-radius: 5px;
 }
 
 .item-traits,

--- a/templates/item-info.widget
+++ b/templates/item-info.widget
@@ -44,6 +44,8 @@ CSS
 .item-info {
   padding-bottom: 12px;
   padding: 10px 15px;
+  border-top-left-radius: 10px;
+  border-top-right-radius: 10px;
 }
 
 .item-info .section.normal {

--- a/templates/item-info.widget
+++ b/templates/item-info.widget
@@ -44,8 +44,8 @@ CSS
 .item-info {
   padding-bottom: 12px;
   padding: 10px 15px;
-  border-top-left-radius: 10px;
-  border-top-right-radius: 10px;
+  border-top-left-radius: 5px;
+  border-top-right-radius: 5px;
 }
 
 .item-info .section.normal {


### PR DESCRIPTION
This sets a 5px border radius on the item boxes which appear at the end of each topic page. The rounded corners are easier on the eyes than the sharp corners.

Screenshots: https://imgur.com/a/72ZMBwl