### PR TITLE
Simplify client types

### DIFF
--- a/back/guide.cabal
+++ b/back/guide.cabal
@@ -96,10 +96,7 @@ library
     Guide.Routes
     Imports
     To
-  build-depends:       Spock
-                     , Spock-digestive
-                     , Spock-lucid
-                     , acid-state
+  build-depends:       acid-state
                      , aeson
                      , aeson-pretty
                      , async
@@ -113,12 +110,12 @@ library
                      , containers >= 0.5
                      , data-default >= 0.5
                      , deepseq >= 1.2.0.0
+                     , df1
+                     , di
+                     , di-core
+                     , di-monad
                      , digestive-functors
                      , directory >= 1.2
-                     , di
-                     , di-monad
-                     , di-core
-                     , df1
                      , ekg
                      , ekg-core
                      , exceptions
@@ -138,9 +135,11 @@ library
                      , http-types
                      , hvect
                      , ilist
+                     , insert-ordered-containers
                      , iproute == 1.7.*
                      , lucid >= 2.9.5 && < 3
                      , megaparsec == 6.*
+                     , microlens
                      , microlens-platform >= 0.3.2
                      , mmorph == 1.*
                      , mtl >= 2.1.1
@@ -159,24 +158,27 @@ library
                      , servant-server
                      , servant-swagger
                      , servant-swagger-ui
-                     , swagger2
                      , shortcut-links >= 0.4.2
+                     , signal
                      , split
+                     , Spock
+                     , Spock-digestive
+                     , Spock-lucid
                      , stache-plus == 0.1.*
                      , stm
                      , stm-containers >= 0.2.14 && < 0.3
+                     , swagger2
                      , template-haskell
                      , text
                      , time >= 1.5
                      , transformers
                      , uniplate
-                     , signal
                      , utf8-string
                      , vector
                      , wai
+                     , wai-cors
                      , wai-middleware-metrics
                      , wai-middleware-static
-                     , wai-cors
                      , warp
                      , xml-conduit
                      , xml-types

--- a/back/src/Imports.hs
+++ b/back/src/Imports.hs
@@ -43,6 +43,8 @@ import qualified Data.ByteString.Lazy as BSL
 import qualified Data.Text.Lazy as TL
 -- Formatting
 import Fmt as X
+-- Call stack
+import GHC.Stack as X (HasCallStack)
 
 -- | Short type for lazy ByteString
 type LByteString = BSL.ByteString


### PR DESCRIPTION
This PR gets rid of `?`, replacing it with explicit schema manipulation.

This also means that now FromJSON instances will accept missing fields as `Nothing` – aeson has built-in logic for treating `Maybe` fields like this, but it doesn't know anything about `Maybe ... ? ...`.