### PR TITLE
Remove -XTemplateHaskell from default extensions

### DIFF
--- a/back/guide.cabal
+++ b/back/guide.cabal
@@ -202,7 +202,6 @@ library
                      , RankNTypes
                      , MultiParamTypeClasses
                      , FunctionalDependencies
-                     , TemplateHaskell
                      , DeriveFunctor
                      , DeriveTraversable
                      , DeriveGeneric
@@ -263,7 +262,6 @@ test-suite tests
                      , RankNTypes
                      , MultiParamTypeClasses
                      , FunctionalDependencies
-                     , TemplateHaskell
                      , DeriveFunctor
                      , DeriveTraversable
                      , DeriveGeneric

--- a/back/src/Guide/Diff.hs
+++ b/back/src/Guide/Diff.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell   #-}
 
 
 -- | Diff- and merge-related things.

--- a/back/src/Guide/Markdown.hs
+++ b/back/src/Guide/Markdown.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE FlexibleInstances  #-}
 {-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell    #-}
 
 
 -- | Everything concerning rendering and processing Markdown.

--- a/back/src/Guide/State.hs
+++ b/back/src/Guide/State.hs
@@ -1,9 +1,10 @@
-{-# LANGUAGE FlexibleContexts  #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE QuasiQuotes       #-}
-{-# LANGUAGE TypeFamilies      #-}
-{-# LANGUAGE StandaloneDeriving#-}
+{-# LANGUAGE FlexibleContexts   #-}
+{-# LANGUAGE FlexibleInstances  #-}
+{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE QuasiQuotes        #-}
+{-# LANGUAGE TypeFamilies       #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell    #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 

--- a/back/src/Guide/Types/Analytics.hs
+++ b/back/src/Guide/Types/Analytics.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeFamilies    #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 
 -- | Types for analytics.

--- a/back/src/Guide/Types/Core.hs
+++ b/back/src/Guide/Types/Core.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE QuasiQuotes         #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE TemplateHaskell     #-}
 
 
 -- | Core types for content.

--- a/back/src/Guide/Types/Edit.hs
+++ b/back/src/Guide/Types/Edit.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeFamilies    #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 
 -- | Types for edits.

--- a/back/src/Guide/Types/User.hs
+++ b/back/src/Guide/Types/User.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies       #-}
+{-# LANGUAGE TemplateHaskell    #-}
 
 -- | A type for users. Currently unused.
 module Guide.Types.User

--- a/back/src/Guide/Utils.hs
+++ b/back/src/Guide/Utils.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE QuasiQuotes                #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE TemplateHaskell            #-}
 
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}

--- a/back/src/Guide/Views/Page.hs
+++ b/back/src/Guide/Views/Page.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes       #-}
+{-# LANGUAGE TemplateHaskell   #-}
 
 
 -- | Page rendering.


### PR DESCRIPTION
With this change, Ormolu can be used to format the whole backend:

```
fd --extension hs . . -x sh -c 'ormolu -m check {}; foo=$?; if [ $foo -ne 100 ] && [ $foo -ne 0 ]; then echo {}:; fi'
```

We can't use Ormolu during development yet because it's too buggy for the time being, but at least we can make it easier to test Ormolu on our codebase.