### PR TITLE
Redo the way undocumented definitions are counted

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,11 +69,11 @@ jobs:
         # "missing documentation".
         - stack --no-terminal exec -- ghc-pkg unregister guide
         - stack --no-terminal build --test --no-run-tests --haddock --no-haddock-deps --haddock-arguments='--no-warnings' 2> haddock.log
-        - awk '/\(src\//' haddock.log | awk 'END { print NR }' > undocumented
-        - awk '{ print "undocumented == " $1 }' undocumented
+        - export uncodumented=$(awk '/\(src\// {count++} END{print count}' haddock.log)
+        - echo "Undocumented definitions: $undocumented"
         - |
-          if [[ `cat undocumented` -gt 251 ]]; then
-            >&2 echo "FAIL: found $(cat undocumented) top-level undocumented definitions. The current limit is 251. Please, add Haddock comments to undocumented definitions!"
+          if [ $undocumented -gt 251 ]; then
+            >&2 echo "FAIL: found $undocumented top-level undocumented definitions. The current limit is 251. Please, add Haddock comments to undocumented definitions!"
             exit 1
           fi
       before_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ jobs:
         # "missing documentation".
         - stack --no-terminal exec -- ghc-pkg unregister guide
         - stack --no-terminal build --test --no-run-tests --haddock --no-haddock-deps --haddock-arguments='--no-warnings' 2> haddock.log
-        - export uncodumented=$(awk '/\(src\// {count++} END{print count}' haddock.log)
+        - export undocumented=$(awk '/\(src\// {count++} END{print count}' haddock.log)
         - |
           echo "Undocumented definitions: $undocumented"
         - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,8 @@ jobs:
         - stack --no-terminal exec -- ghc-pkg unregister guide
         - stack --no-terminal build --test --no-run-tests --haddock --no-haddock-deps --haddock-arguments='--no-warnings' 2> haddock.log
         - export uncodumented=$(awk '/\(src\// {count++} END{print count}' haddock.log)
-        - echo "Undocumented definitions: $undocumented"
+        - |
+          echo "Undocumented definitions: $undocumented"
         - |
           if [ $undocumented -gt 251 ]; then
             >&2 echo "FAIL: found $undocumented top-level undocumented definitions. The current limit is 251. Please, add Haddock comments to undocumented definitions!"


### PR DESCRIPTION
Somehow `awk '{ print "undocumented == " $1 }' undocumented` was changing the number in the file from 225 to 248. I really don't know why.